### PR TITLE
Add docker pulls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Buildbarn Remote Asset - Prototype [![Build status](https://github.com/buildbarn/bb-remote-asset/workflows/master/badge.svg)](https://github.com/buildbarn/bb-remote-asset/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/buildbarn/bb-remote-asset)](https://goreportcard.com/report/github.com/buildbarn/bb-remote-asset)
+# Buildbarn Remote Asset - Prototype [![Build status](https://github.com/buildbarn/bb-remote-asset/workflows/master/badge.svg)](https://github.com/buildbarn/bb-remote-asset/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/buildbarn/bb-remote-asset)](https://goreportcard.com/report/github.com/buildbarn/bb-remote-asset)[![Docker Pulls](https://img.shields.io/docker/pulls/buildbarn/bb-remote-asset?style=plastic)](https://hub.docker.com/r/buildbarn/bb-remote-asset)
 
 **N.B** This repository provides tools which are in early development and may be subject to regular changes to functionality and/or configuration definitions.
 


### PR DESCRIPTION
This adds an additional badge showing the number of pulls for the bb-remote-asset image whilst hyper linking to the docker hub page.