### PR TITLE
Fix a bug with configuration

### DIFF
--- a/pkg/configuration/new_asset_store.go
+++ b/pkg/configuration/new_asset_store.go
@@ -31,10 +31,11 @@ func NewAssetStoreAndCASFromConfiguration(configuration *pb.AssetCacheConfigurat
 		}
 		contentAddressableStorage = contentAddressableStorageInfo.BlobAccess
 	case *pb.AssetCacheConfiguration_ActionCache:
-		contentAddressableStorage, actionCache, err := blobstore_configuration.NewCASAndACBlobAccessFromConfiguration(backend.ActionCache.Blobstore, grpcClientFactory, maximumMessageSizeBytes)
+		cas, actionCache, err := blobstore_configuration.NewCASAndACBlobAccessFromConfiguration(backend.ActionCache.Blobstore, grpcClientFactory, maximumMessageSizeBytes)
 		if err != nil {
 			return nil, nil, err
 		}
+		contentAddressableStorage = cas
 		assetStore = storage.NewActionCacheAssetStore(actionCache, contentAddressableStorage, maximumMessageSizeBytes)
 	}
 	return assetStore, contentAddressableStorage, nil


### PR DESCRIPTION
When using the action cache asset store along with the http fetcher there were nil pointer dereferences due to a bug in the configuration code, this has now been fixed.