### PR TITLE
Add prometheus metrics for resource type qualifier

### DIFF
--- a/pkg/fetch/metrics_fetcher.go
+++ b/pkg/fetch/metrics_fetcher.go
@@ -64,33 +64,25 @@ func NewMetricsFetcher(fetcher Fetcher, clock clock.Clock, name string) Fetcher 
 }
 
 func (mf *metricsFetcher) updateDurationSeconds(vec prometheus.ObserverVec, code codes.Code, timeStart time.Time, qualifiers []*remoteasset.Qualifier) {
-	if len(qualifiers) == 0 {
-		vec.WithLabelValues(code.String(), "N/A").Observe(mf.clock.Now().Sub(timeStart).Seconds())
-	} else {
-		resourceType := "N/A"
-		for _, qualifier := range qualifiers {
-			if qualifier.Name == "resource_type" {
-				resourceType = qualifier.Value
-				break
-			}
+	resourceType := "N/A"
+	for _, qualifier := range qualifiers {
+		if qualifier.Name == "resource_type" {
+			resourceType = qualifier.Value
+			break
 		}
-		vec.WithLabelValues(code.String(), resourceType).Observe(mf.clock.Now().Sub(timeStart).Seconds())
 	}
+	vec.WithLabelValues(code.String(), resourceType).Observe(mf.clock.Now().Sub(timeStart).Seconds())
 }
 
 func (mf *metricsFetcher) updateBlobSizeBytes(vec prometheus.ObserverVec, blobSize float64, qualifiers []*remoteasset.Qualifier) {
-	if len(qualifiers) == 0 {
-		vec.WithLabelValues("N/A").Observe(blobSize)
-	} else {
-		resourceType := "N/A"
-		for _, qualifier := range qualifiers {
-			if qualifier.Name == "resource_type" {
-				resourceType = qualifier.Value
-				break
-			}
+	resourceType := "N/A"
+	for _, qualifier := range qualifiers {
+		if qualifier.Name == "resource_type" {
+			resourceType = qualifier.Value
+			break
 		}
-		vec.WithLabelValues(resourceType).Observe(blobSize)
 	}
+	vec.WithLabelValues(resourceType).Observe(blobSize)
 }
 
 func (mf *metricsFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchBlobRequest) (*remoteasset.FetchBlobResponse, error) {

--- a/pkg/fetch/metrics_fetcher.go
+++ b/pkg/fetch/metrics_fetcher.go
@@ -23,7 +23,7 @@ var (
 			Subsystem: "remote_asset",
 			Name:      "http_fetcher_blob_size_bytes",
 			Help:      "Size of blobs fetched using the http fetcher, in bytes",
-			Buckets:   util.DecimalExponentialBuckets(1, 6, 2),
+			Buckets:   prometheus.ExponentialBuckets(1.0, 2.0, 33),
 		},
 		[]string{"name", "operation", "resource_type"})
 	blobAccessOperationsDurationSeconds = prometheus.NewHistogramVec(

--- a/pkg/push/metrics_push_server.go
+++ b/pkg/push/metrics_push_server.go
@@ -66,33 +66,25 @@ func NewMetricsAssetPushServer(ps remoteasset.PushServer, clock clock.Clock, nam
 }
 
 func (s *metricsAssetPushServer) updateDurationSeconds(vec prometheus.ObserverVec, code codes.Code, timeStart time.Time, qualifiers []*remoteasset.Qualifier) {
-	if len(qualifiers) == 0 {
-		vec.WithLabelValues(code.String(), "N/A").Observe(s.clock.Now().Sub(timeStart).Seconds())
-	} else {
-		resourceType := "N/A"
-		for _, qualifier := range qualifiers {
-			if qualifier.Name == "resource_type" {
-				resourceType = qualifier.Value
-				break
-			}
+	resourceType := "N/A"
+	for _, qualifier := range qualifiers {
+		if qualifier.Name == "resource_type" {
+			resourceType = qualifier.Value
+			break
 		}
-		vec.WithLabelValues(code.String(), resourceType).Observe(s.clock.Now().Sub(timeStart).Seconds())
 	}
+	vec.WithLabelValues(code.String(), resourceType).Observe(s.clock.Now().Sub(timeStart).Seconds())
 }
 
 func (s *metricsAssetPushServer) updateBlobSizeBytes(vec prometheus.ObserverVec, blobSize float64, qualifiers []*remoteasset.Qualifier) {
-	if len(qualifiers) == 0 {
-		vec.WithLabelValues("N/A").Observe(blobSize)
-	} else {
-		resourceType := "N/A"
-		for _, qualifier := range qualifiers {
-			if qualifier.Name == "resource_type" {
-				resourceType = qualifier.Value
-				break
-			}
+	resourceType := "N/A"
+	for _, qualifier := range qualifiers {
+		if qualifier.Name == "resource_type" {
+			resourceType = qualifier.Value
+			break
 		}
-		vec.WithLabelValues(resourceType).Observe(blobSize)
 	}
+	vec.WithLabelValues(resourceType).Observe(blobSize)
 }
 
 func (s *metricsAssetPushServer) PushBlob(ctx context.Context, req *remoteasset.PushBlobRequest) (*remoteasset.PushBlobResponse, error) {

--- a/pkg/push/metrics_push_server.go
+++ b/pkg/push/metrics_push_server.go
@@ -22,7 +22,7 @@ var (
 			Subsystem: "push_server",
 			Name:      "push_server_blob_size_bytes",
 			Help:      "Size of blobs being pushed, in bytes.",
-			Buckets:   util.DecimalExponentialBuckets(1, 6, 2),
+			Buckets:   prometheus.ExponentialBuckets(1.0, 2.0, 33),
 		},
 		[]string{"name", "operation", "resource_type"})
 	pushServerOperationsDurationSeconds = prometheus.NewHistogramVec(


### PR DESCRIPTION
This PR adds a label showing the resource_type of the request to the prometheus metrics.

It also adjusts the buckets used for blob sizes as they were not set up in sensible way.