### PR TITLE
Support Bazel auth_headers qualifier

### DIFF
--- a/pkg/fetch/BUILD.bazel
+++ b/pkg/fetch/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "auth_headers.go",
         "caching_fetcher.go",
         "error_fetcher.go",
         "fetcher.go",

--- a/pkg/fetch/auth_headers.go
+++ b/pkg/fetch/auth_headers.go
@@ -1,0 +1,25 @@
+package fetch
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// AuthHeaders is a map from target URI to headers to be applied for the request
+type AuthHeaders map[string]map[string]string
+
+// NewAuthHeadersFromQualifier creates an AuthHeaders from the qualifier payload
+func NewAuthHeadersFromQualifier(value string) (*AuthHeaders, error) {
+	var ah AuthHeaders
+	err := json.Unmarshal([]byte(value), &ah)
+	return &ah, err
+}
+
+// ApplyHeaders mutates a http.Request to apply headers requested by the client.
+func (ah AuthHeaders) ApplyHeaders(uri string, req *http.Request) {
+	if headers, ok := ah[uri]; ok {
+		for header, val := range headers {
+			req.Header.Set(header, val)
+		}
+	}
+}


### PR DESCRIPTION
This allows for headers set by repository rules (via repository_ctx.download auth parameter) to be handled by bb-remote-asset