### PR TITLE
AC: Treat Directories as blobs

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -20,8 +20,6 @@ go_library(
         "@com_github_buildbarn_bb_storage//pkg/blobstore",
         "@com_github_buildbarn_bb_storage//pkg/blobstore/buffer",
         "@com_github_buildbarn_bb_storage//pkg/digest",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],


### PR DESCRIPTION
We currently do some cleverness to pop `Directory` objects into the `OutputDirectories` field of the `ActionResult` for semantic purposes. Unfortunately doing this requires jumping over many hurdles, partially of our own making and partially from REAPI.

To detect whether the object is a `Directory`, we fetch it from CAS and attempt to unmarshal it into a `Directory` message.  We then must convert it to a `Tree` to store in the `ActionResult`, which also requires the raw proto.

The catch is that things that are not `Directory` messages may successfully unmarshal into one -- as a motivating example, BuildStream's [`Source` proto](https://github.com/apache/buildstream/blob/master/src/buildstream/_protos/buildstream/v2/source.proto) is such a message.  When this happens, we're very likely to fail the request as we attempt to use the corrupted `Directory` we've created.  In the BuildStream case, we hit an error with "Unknown Digest Function", as a `Digest` proto is loaded as `nil`.

To solve this, we could pass through data on whether the asset is supposed to be a directory or not, however doing so is inelegant and has another subtle problem -- if the client decides to use `PushDirectory` to push something that isn't a `Directory` (which isn't explicitly banned by the spec), then we will error.

As the `Action` and `ActionResult`s we generate are intended only to be used by us, we can instead break the semantics somewhat and treat the `Directory` as an opaque file, as we do for blobs.

Note: this intentionally breaks the sharing of `Action`s should the `RemoteExecutionFetcher` be used.  This feels more correct to me, as we were overwriting the one we actually ran anyway.  Under this usage we instead get multiple `Action`s pointing to the same `ActionResult` -- one for the actually executed `Action`, and another for the asset reference.

Fixes #33 