### PR TITLE
Remove reference to the project being a prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# Buildbarn Remote Asset - Prototype [![Build status](https://github.com/buildbarn/bb-remote-asset/workflows/master/badge.svg)](https://github.com/buildbarn/bb-remote-asset/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/buildbarn/bb-remote-asset)](https://goreportcard.com/report/github.com/buildbarn/bb-remote-asset)[![Docker Pulls](https://img.shields.io/docker/pulls/buildbarn/bb-remote-asset?style=plastic)](https://hub.docker.com/r/buildbarn/bb-remote-asset)
-
-**N.B** This repository provides tools which are in early development and may be
-subject to regular changes to functionality and/or configuration definitions.
+# Buildbarn Remote Asset [![Build status](https://github.com/buildbarn/bb-remote-asset/workflows/master/badge.svg)](https://github.com/buildbarn/bb-remote-asset/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/buildbarn/bb-remote-asset)](https://goreportcard.com/report/github.com/buildbarn/bb-remote-asset)[![Docker Pulls](https://img.shields.io/docker/pulls/buildbarn/bb-remote-asset?style=plastic)](https://hub.docker.com/r/buildbarn/bb-remote-asset)
 
 This repository provides a service for the [remote
 asset](https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/asset/v1/remote_asset.proto)


### PR DESCRIPTION
The project is now stable enough that it should no longer be described as a prototype