### PR TITLE
.github/workflows/master.yaml: Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -61,7 +61,7 @@
             },
             {
                "name": "linux_amd64: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.linux_amd64",
                   "path": "bb_remote_asset"
@@ -77,7 +77,7 @@
             },
             {
                "name": "linux_386: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.linux_386",
                   "path": "bb_remote_asset"
@@ -93,7 +93,7 @@
             },
             {
                "name": "linux_arm: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.linux_arm",
                   "path": "bb_remote_asset"
@@ -109,7 +109,7 @@
             },
             {
                "name": "linux_arm64: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.linux_arm64",
                   "path": "bb_remote_asset"
@@ -125,7 +125,7 @@
             },
             {
                "name": "darwin_amd64: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.darwin_amd64",
                   "path": "bb_remote_asset"
@@ -141,7 +141,7 @@
             },
             {
                "name": "darwin_arm64: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.darwin_arm64",
                   "path": "bb_remote_asset"
@@ -157,7 +157,7 @@
             },
             {
                "name": "freebsd_amd64: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.freebsd_amd64",
                   "path": "bb_remote_asset"
@@ -173,7 +173,7 @@
             },
             {
                "name": "windows_amd64: upload bb_remote_asset",
-               "uses": "actions/upload-artifact@v2-preview",
+               "uses": "actions/upload-artifact@v4",
                "with": {
                   "name": "bb_remote_asset.windows_amd64",
                   "path": "bb_remote_asset.exe"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "toolchains_llvm", version = "1.0.0")
 
 git_override(
     module_name = "com_github_buildbarn_bb_storage",
-    commit = "914e53aad8cd16fc4c1ecd7f706149e8440ea24a",
+    commit = "a889bc06a4070e34f5b7d85073dabaa37bfc3027",
     remote = "https://github.com/buildbarn/bb-storage.git",
 )
 


### PR DESCRIPTION
This fixes current build in master: https://github.com/buildbarn/bb-remote-asset/actions/runs/10802836077/job/29965674380

v2-preview is deprecated, see: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
