### PR TITLE
Tidy up action cache asset store

### DIFF
--- a/pkg/fetch/caching_fetcher_test.go
+++ b/pkg/fetch/caching_fetcher_test.go
@@ -35,7 +35,7 @@ func TestFetchBlobCaching(t *testing.T) {
 		Uris:         []string{uri},
 	}
 	blobDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
-	refDigest, err := storage.AssetReferenceToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
 	require.NoError(t, err)
 
 	t.Logf("Ref digest was %v", refDigest)
@@ -93,7 +93,7 @@ func TestFetchDirectoryCaching(t *testing.T) {
 		Uris:         []string{uri},
 	}
 	dirDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
-	refDigest, err := storage.AssetReferenceToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)
@@ -148,7 +148,7 @@ func TestCachingFetcherExpiry(t *testing.T) {
 		InstanceName: "foo",
 		Uris:         []string{uri},
 	}
-	refDigest, err := storage.AssetReferenceToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)
@@ -188,7 +188,7 @@ func TestCachingFetcherOldestContentAccepted(t *testing.T) {
 		Uris:                  []string{uri},
 		OldestContentAccepted: timestamppb.Now(),
 	}
-	refDigest, err := storage.AssetReferenceToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)

--- a/pkg/fetch/remote_execution_fetcher.go
+++ b/pkg/fetch/remote_execution_fetcher.go
@@ -46,7 +46,7 @@ func (rf *remoteExecutionFetcher) fetchCommon(ctx context.Context, req *remoteas
 	}
 	for _, uri := range req.Uris {
 		command := commandGenerator(uri)
-		commandDigest, err := storage.ProtoToDigest(command)
+		_, commandDigest, err := storage.ProtoSerialise(command)
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -59,7 +59,7 @@ func (rf *remoteExecutionFetcher) fetchCommon(ctx context.Context, req *remoteas
 			CommandDigest:   commandDigest,
 			InputRootDigest: storage.EmptyDigest,
 		}
-		actionDigest, err := storage.ProtoToDigest(action)
+		_, actionDigest, err := storage.ProtoSerialise(action)
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -208,7 +208,7 @@ func (rf *remoteExecutionFetcher) FetchDirectory(ctx context.Context, req *remot
 		return nil, err
 	}
 	root := tree.(*remoteexecution.Tree).Root
-	rootDigest, err := storage.ProtoToDigest(root)
+	_, rootDigest, err := storage.ProtoSerialise(root)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (rf *remoteExecutionFetcher) FetchDirectory(ctx context.Context, req *remot
 		return nil, err
 	}
 	for _, child := range tree.(*remoteexecution.Tree).Children {
-		childDigest, err := storage.ProtoToDigest(child)
+		_, childDigest, err := storage.ProtoSerialise(child)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/push/push_server_test.go
+++ b/pkg/push/push_server_test.go
@@ -42,7 +42,7 @@ func TestPushServerPushBlobSuccess(t *testing.T) {
 		BlobDigest:   blobDigest,
 		Qualifiers:   qualifiers,
 	}
-	refDigest, err := storage.AssetReferenceToDigest(storage.NewAssetReference([]string{uri}, qualifiers), instanceName)
+	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, qualifiers), instanceName)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)
@@ -82,7 +82,7 @@ func TestPushServerPushDirectorySuccess(t *testing.T) {
 		RootDirectoryDigest: rootDirectoryDigest,
 		Qualifiers:          qualifiers,
 	}
-	refDigest, err := storage.AssetReferenceToDigest(storage.NewAssetReference([]string{uri}, qualifiers), instanceName)
+	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, qualifiers), instanceName)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)

--- a/pkg/storage/action_cache_asset_store_test.go
+++ b/pkg/storage/action_cache_asset_store_test.go
@@ -280,9 +280,9 @@ func TestActionCacheAssetStorePutRecursiveDirectory(t *testing.T) {
 		},
 	}
 
-	rootDirectoryDigest, err := storage.ProtoToDigest(tree.Root)
+	_, rootDirectoryDigest, err := storage.ProtoSerialise(tree.Root)
 	require.NoError(t, err)
-	treeDigest, err := storage.ProtoToDigest(tree)
+	_, treeDigest, err := storage.ProtoSerialise(tree)
 	require.NoError(t, err)
 
 	t.Logf("rootDirectoryDigest %v", rootDirectoryDigest)

--- a/pkg/storage/asset_reference.go
+++ b/pkg/storage/asset_reference.go
@@ -1,17 +1,12 @@
 package storage
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"sort"
 
 	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
-	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 
 	"github.com/buildbarn/bb-remote-asset/pkg/proto/asset"
 	"github.com/buildbarn/bb-remote-asset/pkg/qualifier"
-	"github.com/buildbarn/bb-storage/pkg/digest"
-	"google.golang.org/protobuf/proto"
 )
 
 // NewAssetReference creates a new AssetReference from a URI and a list
@@ -22,56 +17,4 @@ func NewAssetReference(uris []string, qualifiers []*remoteasset.Qualifier) *asse
 	sort.Sort(sortedQualifiers)
 	sort.Strings(uris)
 	return &asset.AssetReference{Uris: uris, Qualifiers: sortedQualifiers.ToArray()}
-}
-
-// AssetReferenceToDigest converts an AssetReference into a bb-storage Digest of its
-// wire format
-func AssetReferenceToDigest(ar *asset.AssetReference, instance digest.InstanceName) (digest.Digest, error) {
-	wireFormat, err := proto.Marshal(ar)
-	if err != nil {
-		return digest.Digest{}, err
-	}
-
-	hash := sha256.Sum256(wireFormat)
-	sizeBytes := int64(len(wireFormat))
-
-	// GetDigestFunction takes a length of a string repr of a hash, not the length
-	// of the byte array of the hash; multiply by 2 to convert to the former.
-	digestFunction, err := instance.GetDigestFunction(remoteexecution.DigestFunction_UNKNOWN, len(hash)*2)
-	if err != nil {
-		return digest.Digest{}, err
-	}
-
-	return digestFunction.NewDigest(hex.EncodeToString(hash[:]), sizeBytes)
-}
-
-func assetReferenceToAction(ar *asset.AssetReference, directoryDigest *remoteexecution.Digest) (*remoteexecution.Action, *remoteexecution.Command, error) {
-	command := &remoteexecution.Command{
-		Arguments:             ar.Uris,
-		OutputPaths:           []string{"out"},
-		OutputDirectoryFormat: remoteexecution.Command_TREE_AND_DIRECTORY,
-	}
-	commandDigest, err := ProtoToDigest(command)
-	if err != nil {
-		return nil, nil, err
-	}
-	action := &remoteexecution.Action{
-		CommandDigest:   commandDigest,
-		InputRootDigest: directoryDigest,
-	}
-	return action, command, nil
-}
-
-// ProtoToDigest converts an arbitrary proto to a remote execution Digest
-func ProtoToDigest(pb proto.Message) (*remoteexecution.Digest, error) {
-	wireFormat, err := proto.Marshal(pb)
-	if err != nil {
-		return nil, err
-	}
-	hash := sha256.Sum256(wireFormat)
-
-	return &remoteexecution.Digest{
-		Hash:      hex.EncodeToString(hash[:]),
-		SizeBytes: int64(len(wireFormat)),
-	}, nil
 }

--- a/pkg/storage/blob_access_asset_store.go
+++ b/pkg/storage/blob_access_asset_store.go
@@ -25,7 +25,7 @@ func NewBlobAccessAssetStore(ba blobstore.BlobAccess, maximumMessageSizeBytes in
 
 // Get a digest given a reference
 func (rs *blobAccessAssetStore) Get(ctx context.Context, ref *asset.AssetReference, instance digest.InstanceName) (*asset.Asset, error) {
-	refDigest, err := AssetReferenceToDigest(ref, instance)
+	refDigest, err := ProtoToDigest(ref, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (rs *blobAccessAssetStore) Get(ctx context.Context, ref *asset.AssetReferen
 
 // Put a digest into the store referenced by a given reference
 func (rs *blobAccessAssetStore) Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, instance digest.InstanceName) error {
-	refDigest, err := AssetReferenceToDigest(ref, instance)
+	refDigest, err := ProtoToDigest(ref, instance)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/blob_access_asset_store_test.go
+++ b/pkg/storage/blob_access_asset_store_test.go
@@ -27,7 +27,7 @@ func TestBlobAccessAssetStorePut(t *testing.T) {
 	uri := "https://example.com/example.txt"
 	assetRef := storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{})
 	assetData := storage.NewBlobAsset(blobDigest, timestamppb.Now())
-	refDigest, err := storage.AssetReferenceToDigest(assetRef, instanceName)
+	refDigest, err := storage.ProtoToDigest(assetRef, instanceName)
 	require.NoError(t, err)
 
 	blobAccess := mock.NewMockBlobAccess(ctrl)
@@ -54,7 +54,7 @@ func TestBlobAccessAssetStoreGet(t *testing.T) {
 	blobDigest := &remoteexecution.Digest{Hash: "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f", SizeBytes: 222}
 	uri := "https://example.com/example.txt"
 	assetRef := storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{})
-	refDigest, err := storage.AssetReferenceToDigest(assetRef, instanceName)
+	refDigest, err := storage.ProtoToDigest(assetRef, instanceName)
 	require.NoError(t, err)
 
 	buf := buffer.NewProtoBufferFromProto(&asset.Asset{Digest: blobDigest}, buffer.UserProvided)

--- a/pkg/storage/digest.go
+++ b/pkg/storage/digest.go
@@ -1,10 +1,55 @@
 package storage
 
-import remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/buildbarn/bb-storage/pkg/digest"
+)
 
 // EmptyDigest is a REv2 Digest representing an object of size 0 hashed
 // with SHA256
 var EmptyDigest = &remoteexecution.Digest{
 	Hash:      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 	SizeBytes: 0,
+}
+
+// ProtoSerialise serialises an arbitrary protobuf message into its wire format and
+// a Remote Execution API Digest of the format.  This is very useful for interacting
+// with the Remote Execution API
+func ProtoSerialise(pb proto.Message) ([]byte, *remoteexecution.Digest, error) {
+	wireFormat, err := proto.Marshal(pb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hash := sha256.Sum256(wireFormat)
+
+	return wireFormat,
+		&remoteexecution.Digest{
+			Hash:      hex.EncodeToString(hash[:]),
+			SizeBytes: int64(len(wireFormat)),
+		}, nil
+}
+
+// ProtoToDigest converts an arbitrary protobuf message into a Buildbarn-internal
+// Digest of its content.
+func ProtoToDigest(pb proto.Message, instance digest.InstanceName) (digest.Digest, error) {
+	_, reapiDigest, err := ProtoSerialise(pb)
+	if err != nil {
+		return digest.Digest{}, err
+	}
+	digestFunction, err := instance.GetDigestFunction(remoteexecution.DigestFunction_UNKNOWN, len(reapiDigest.GetHash()))
+	if err != nil {
+		return digest.Digest{}, err
+	}
+	bbDigest, err := digestFunction.NewDigestFromProto(reapiDigest)
+	if err != nil {
+		return digest.Digest{}, err
+	}
+	return bbDigest, nil
 }


### PR DESCRIPTION
The Action Cache Asset Store is a bit hard to work with at the moment.  Lots of logic is included in the `Get` and `Put` methods that can be extracted and shared, while also clarifying what's really going on in these methods.

I've also modified some of the utility functions to be more generic which has removed a load of boilerplate.