### PR TITLE
Fix validation of new bazel http header qualifiers

### DIFF
--- a/pkg/fetch/http_fetcher.go
+++ b/pkg/fetch/http_fetcher.go
@@ -102,7 +102,13 @@ func (hf *httpFetcher) FetchDirectory(ctx context.Context, req *remoteasset.Fetc
 }
 
 func (hf *httpFetcher) CheckQualifiers(qualifiers qualifier.Set) qualifier.Set {
-	return qualifier.Difference(qualifiers, qualifier.NewSet([]string{"checksum.sri", "bazel.auth_headers", "bazel.canonical_id"}))
+	toRemove := qualifier.NewSet([]string{"checksum.sri", QualifierLegacyBazelHTTPHeaders, "bazel.canonical_id"})
+	for name := range qualifiers {
+		if strings.HasPrefix(name, QualifierHTTPHeaderPrefix) || strings.HasPrefix(name, QualifierHTTPHeaderURLPrefix) {
+			toRemove.Add(name)
+		}
+	}
+	return qualifier.Difference(qualifiers, toRemove)
 }
 
 func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, instanceName bb_digest.InstanceName, expectedDigest string, digestFunctionEnum remoteexecution.DigestFunction_Value, auth *AuthHeaders) (buffer.Buffer, bb_digest.Digest) {

--- a/pkg/fetch/http_fetcher_test.go
+++ b/pkg/fetch/http_fetcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/buildbarn/bb-remote-asset/internal/mock"
 	"github.com/buildbarn/bb-remote-asset/pkg/fetch"
+	"github.com/buildbarn/bb-remote-asset/pkg/qualifier"
 	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
 
@@ -334,6 +335,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 				},
 			},
 		}
+		require.Empty(t, HTTPFetcher.CheckQualifiers(qualifier.QualifiersToSet(request.Qualifiers)))
 		matcher := &headerMatcher{
 			headers: map[string]string{
 				"Authorization": "Bearer letmein",
@@ -376,6 +378,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 				},
 			},
 		}
+		require.Empty(t, HTTPFetcher.CheckQualifiers(qualifier.QualifiersToSet(request.Qualifiers)))
 		matcherReq1 := &headerMatcher{
 			headers: map[string]string{
 				"Authorization": "Bearer anothertoken",


### PR DESCRIPTION
Support for this was added in #49 but it seems the validation code wasn't updated. I ran into this whilst using rules_oci, which sets various headers, leading to errors like:
```
field:"qualifiers.name" description:"\"http_header:Accept\" not supported"
field:"qualifiers.name" description:"\"http_header:Docker-Distribution-API-Version\" not supported"]
```