### PR TITLE
Support DigestFunction in the Remote Asset API

### DIFF
--- a/pkg/fetch/BUILD.bazel
+++ b/pkg/fetch/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "logging_fetcher.go",
         "metrics_fetcher.go",
         "remote_execution_fetcher.go",
+        "utils.go",
         "validating_fetcher.go",
     ],
     importpath = "github.com/buildbarn/bb-remote-asset/pkg/fetch",

--- a/pkg/fetch/caching_fetcher_test.go
+++ b/pkg/fetch/caching_fetcher_test.go
@@ -28,6 +28,8 @@ func TestFetchBlobCaching(t *testing.T) {
 
 	instanceName, err := bb_digest.NewInstanceName("")
 	require.NoError(t, err)
+	digestFunction, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
 
 	uri := "www.example.com"
 	request := &remoteasset.FetchBlobRequest{
@@ -35,7 +37,7 @@ func TestFetchBlobCaching(t *testing.T) {
 		Uris:         []string{uri},
 	}
 	blobDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
-	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	_, refDigest, err := storage.ProtoSerialise(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), digestFunction)
 	require.NoError(t, err)
 
 	t.Logf("Ref digest was %v", refDigest)
@@ -86,6 +88,8 @@ func TestFetchDirectoryCaching(t *testing.T) {
 
 	instanceName, err := bb_digest.NewInstanceName("")
 	require.NoError(t, err)
+	digestFunction, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
 
 	uri := "www.example.com"
 	request := &remoteasset.FetchDirectoryRequest{
@@ -93,7 +97,7 @@ func TestFetchDirectoryCaching(t *testing.T) {
 		Uris:         []string{uri},
 	}
 	dirDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
-	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	_, refDigest, err := storage.ProtoSerialise(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), digestFunction)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)
@@ -142,13 +146,15 @@ func TestCachingFetcherExpiry(t *testing.T) {
 
 	instanceName, err := digest.NewInstanceName("foo")
 	require.NoError(t, err)
+	digestFunction, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
 
 	uri := "https://example.com/example.tar.gz"
 	request := &remoteasset.FetchBlobRequest{
 		InstanceName: "foo",
 		Uris:         []string{uri},
 	}
-	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	_, refDigest, err := storage.ProtoSerialise(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), digestFunction)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)
@@ -181,6 +187,8 @@ func TestCachingFetcherOldestContentAccepted(t *testing.T) {
 
 	instanceName, err := digest.NewInstanceName("bar")
 	require.NoError(t, err)
+	digestFunction, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
 
 	uri := "https://example.com/exampleblob.zip"
 	request := &remoteasset.FetchBlobRequest{
@@ -188,7 +196,7 @@ func TestCachingFetcherOldestContentAccepted(t *testing.T) {
 		Uris:                  []string{uri},
 		OldestContentAccepted: timestamppb.Now(),
 	}
-	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), instanceName)
+	_, refDigest, err := storage.ProtoSerialise(storage.NewAssetReference([]string{uri}, []*remoteasset.Qualifier{}), digestFunction)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)

--- a/pkg/fetch/utils.go
+++ b/pkg/fetch/utils.go
@@ -1,0 +1,26 @@
+package fetch
+
+import (
+	"github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/buildbarn/bb-storage/pkg/util"
+
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// getDigestFunction gets the digest function specified by a request or uses SHA 256 by default
+func getDigestFunction(digestFunction remoteexecution.DigestFunction_Value, instanceName string) (digest.Function, error) {
+	instance, err := digest.NewInstanceName(instanceName)
+	if err != nil {
+		return digest.Function{}, util.StatusWrapf(err, "Invalid instance name %#v", instanceName)
+	}
+
+	// As per the API spec, default to SHA 256 if no digest function is set.
+	if digestFunction == remoteexecution.DigestFunction_UNKNOWN {
+		digestFunction = remoteexecution.DigestFunction_SHA256
+	}
+
+	// The value of the fallback hash length is unused, because we never have an
+	// unknown value for the digest function enum.  Let's set it to 0 rather than
+	// any actual value
+	return instance.GetDigestFunction(digestFunction, 0)
+}

--- a/pkg/push/BUILD.bazel
+++ b/pkg/push/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/storage",
         "@bazel_remote_apis//build/bazel/remote/asset/v1:remote_asset_go_proto",
+        "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@com_github_buildbarn_bb_storage//pkg/clock",
         "@com_github_buildbarn_bb_storage//pkg/digest",
         "@com_github_buildbarn_bb_storage//pkg/util",

--- a/pkg/push/push_server.go
+++ b/pkg/push/push_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-remote-asset/pkg/storage"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/util"
@@ -14,6 +15,18 @@ import (
 type assetPushServer struct {
 	assetStore               storage.AssetStore
 	allowUpdatesForInstances map[digest.InstanceName]bool
+}
+
+// getDigestFunction is a convenient wrapper to get a Buildbarn digest Function
+// based on the instance name.  If digestFunction is unknown, then we attempt to
+// guess the function based on the length of sentDigest's hash.
+func getDigestFunction(digestFunction remoteexecution.DigestFunction_Value, instanceName string, sentDigest *remoteexecution.Digest) (digest.Function, error) {
+	instance, err := digest.NewInstanceName(instanceName)
+	if err != nil {
+		return digest.Function{}, util.StatusWrapf(err, "Invalid instance name %#v", instanceName)
+	}
+
+	return instance.GetDigestFunction(digestFunction, len(sentDigest.GetHash()))
 }
 
 // NewAssetPushServer creates a gRPC service for serving the contents
@@ -30,18 +43,18 @@ func (s *assetPushServer) PushBlob(ctx context.Context, req *remoteasset.PushBlo
 		return nil, status.Errorf(codes.InvalidArgument, "PushBlob requires at least one URI")
 	}
 
-	instanceName, err := digest.NewInstanceName(req.InstanceName)
+	digestFunction, err := getDigestFunction(req.DigestFunction, req.InstanceName, req.BlobDigest)
 	if err != nil {
-		return nil, util.StatusWrapf(err, "Invalid instance name %#v", req.InstanceName)
+		return nil, err
 	}
 
-	if !s.allowUpdatesForInstances[instanceName] {
+	if !s.allowUpdatesForInstances[digestFunction.GetInstanceName()] {
 		return nil, status.Errorf(codes.PermissionDenied, "This service does not accept Blobs for instance %#v", req.InstanceName)
 	}
 
 	assetRef := storage.NewAssetReference(req.Uris, req.Qualifiers)
 	assetData := storage.NewBlobAsset(req.BlobDigest, req.ExpireAt)
-	err = s.assetStore.Put(ctx, assetRef, assetData, instanceName)
+	err = s.assetStore.Put(ctx, assetRef, assetData, digestFunction)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +63,7 @@ func (s *assetPushServer) PushBlob(ctx context.Context, req *remoteasset.PushBlo
 		for _, uri := range req.Uris {
 			assetRef := storage.NewAssetReference([]string{uri}, req.Qualifiers)
 			assetData := storage.NewBlobAsset(req.BlobDigest, req.ExpireAt)
-			err = s.assetStore.Put(ctx, assetRef, assetData, instanceName)
+			err = s.assetStore.Put(ctx, assetRef, assetData, digestFunction)
 			if err != nil {
 				return nil, err
 			}
@@ -64,18 +77,18 @@ func (s *assetPushServer) PushDirectory(ctx context.Context, req *remoteasset.Pu
 		return nil, status.Errorf(codes.InvalidArgument, "PushDirectory requires at least one URI")
 	}
 
-	instanceName, err := digest.NewInstanceName(req.InstanceName)
+	digestFunction, err := getDigestFunction(req.DigestFunction, req.InstanceName, req.RootDirectoryDigest)
 	if err != nil {
-		return nil, util.StatusWrapf(err, "Invalid instance name %#v", req.InstanceName)
+		return nil, err
 	}
 
-	if !s.allowUpdatesForInstances[instanceName] {
+	if !s.allowUpdatesForInstances[digestFunction.GetInstanceName()] {
 		return nil, status.Errorf(codes.PermissionDenied, "This service does not accept Directories for instance %#v", req.InstanceName)
 	}
 
 	assetRef := storage.NewAssetReference(req.Uris, req.Qualifiers)
 	assetData := storage.NewDirectoryAsset(req.RootDirectoryDigest, req.ExpireAt)
-	err = s.assetStore.Put(ctx, assetRef, assetData, instanceName)
+	err = s.assetStore.Put(ctx, assetRef, assetData, digestFunction)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +97,7 @@ func (s *assetPushServer) PushDirectory(ctx context.Context, req *remoteasset.Pu
 		for _, uri := range req.Uris {
 			assetRef := storage.NewAssetReference([]string{uri}, req.Qualifiers)
 			assetData := storage.NewDirectoryAsset(req.RootDirectoryDigest, req.ExpireAt)
-			err = s.assetStore.Put(ctx, assetRef, assetData, instanceName)
+			err = s.assetStore.Put(ctx, assetRef, assetData, digestFunction)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/push/push_server_test.go
+++ b/pkg/push/push_server_test.go
@@ -24,6 +24,9 @@ func TestPushServerPushBlobSuccess(t *testing.T) {
 
 	instanceName, err := digest.NewInstanceName("")
 	require.NoError(t, err)
+	digestFunction, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
+
 	blobDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
 	uri := "https://example.com/example.txt"
 	qualifiers := []*remoteasset.Qualifier{
@@ -42,7 +45,7 @@ func TestPushServerPushBlobSuccess(t *testing.T) {
 		BlobDigest:   blobDigest,
 		Qualifiers:   qualifiers,
 	}
-	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, qualifiers), instanceName)
+	_, refDigest, err := storage.ProtoSerialise(storage.NewAssetReference([]string{uri}, qualifiers), digestFunction)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)
@@ -68,6 +71,9 @@ func TestPushServerPushDirectorySuccess(t *testing.T) {
 
 	instanceName, err := digest.NewInstanceName("")
 	require.NoError(t, err)
+	digestFunction, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
+
 	rootDirectoryDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
 	uri := "https://example.com/example.txt"
 	qualifiers := []*remoteasset.Qualifier{
@@ -82,7 +88,7 @@ func TestPushServerPushDirectorySuccess(t *testing.T) {
 		RootDirectoryDigest: rootDirectoryDigest,
 		Qualifiers:          qualifiers,
 	}
-	refDigest, err := storage.ProtoToDigest(storage.NewAssetReference([]string{uri}, qualifiers), instanceName)
+	_, refDigest, err := storage.ProtoSerialise(storage.NewAssetReference([]string{uri}, qualifiers), digestFunction)
 	require.NoError(t, err)
 
 	backend := mock.NewMockBlobAccess(ctrl)

--- a/pkg/storage/asset_store.go
+++ b/pkg/storage/asset_store.go
@@ -10,6 +10,6 @@ import (
 // AssetStore is a wrapper around a BlobAccess to inteface well with
 // AssetReference messages
 type AssetStore interface {
-	Get(ctx context.Context, ref *asset.AssetReference, instance digest.InstanceName) (*asset.Asset, error)
-	Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, instance digest.InstanceName) error
+	Get(ctx context.Context, ref *asset.AssetReference, digestFunction digest.Function) (*asset.Asset, error)
+	Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, digestFunction digest.Function) error
 }

--- a/pkg/storage/authorizing_asset_store.go
+++ b/pkg/storage/authorizing_asset_store.go
@@ -25,17 +25,17 @@ func NewAuthorizingAssetStore(as AssetStore, fetchAuthorizer, pushAuthorizer aut
 }
 
 // Get is a wrapper that validates credentials against FetchAuthorizer
-func (aas *AuthorizingAssetStore) Get(ctx context.Context, ref *asset.AssetReference, instanceName digest.InstanceName) (*asset.Asset, error) {
-	if err := auth.AuthorizeSingleInstanceName(ctx, aas.fetchAuthorizer, instanceName); err != nil {
+func (aas *AuthorizingAssetStore) Get(ctx context.Context, ref *asset.AssetReference, digestFunction digest.Function) (*asset.Asset, error) {
+	if err := auth.AuthorizeSingleInstanceName(ctx, aas.fetchAuthorizer, digestFunction.GetInstanceName()); err != nil {
 		return nil, err
 	}
-	return aas.AssetStore.Get(ctx, ref, instanceName)
+	return aas.AssetStore.Get(ctx, ref, digestFunction)
 }
 
 // Put is a wrapper that validates credentials against PushAuthorizer
-func (aas *AuthorizingAssetStore) Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, instanceName digest.InstanceName) error {
-	if err := auth.AuthorizeSingleInstanceName(ctx, aas.pushAuthorizer, instanceName); err != nil {
+func (aas *AuthorizingAssetStore) Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, digestFunction digest.Function) error {
+	if err := auth.AuthorizeSingleInstanceName(ctx, aas.pushAuthorizer, digestFunction.GetInstanceName()); err != nil {
 		return err
 	}
-	return aas.AssetStore.Put(ctx, ref, data, instanceName)
+	return aas.AssetStore.Put(ctx, ref, data, digestFunction)
 }

--- a/pkg/storage/blob_access_asset_store.go
+++ b/pkg/storage/blob_access_asset_store.go
@@ -24,8 +24,8 @@ func NewBlobAccessAssetStore(ba blobstore.BlobAccess, maximumMessageSizeBytes in
 }
 
 // Get a digest given a reference
-func (rs *blobAccessAssetStore) Get(ctx context.Context, ref *asset.AssetReference, instance digest.InstanceName) (*asset.Asset, error) {
-	refDigest, err := ProtoToDigest(ref, instance)
+func (rs *blobAccessAssetStore) Get(ctx context.Context, ref *asset.AssetReference, digestFunction digest.Function) (*asset.Asset, error) {
+	_, refDigest, err := ProtoSerialise(ref, digestFunction)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +40,8 @@ func (rs *blobAccessAssetStore) Get(ctx context.Context, ref *asset.AssetReferen
 }
 
 // Put a digest into the store referenced by a given reference
-func (rs *blobAccessAssetStore) Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, instance digest.InstanceName) error {
-	refDigest, err := ProtoToDigest(ref, instance)
+func (rs *blobAccessAssetStore) Put(ctx context.Context, ref *asset.AssetReference, data *asset.Asset, digestFunction digest.Function) error {
+	_, refDigest, err := ProtoSerialise(ref, digestFunction)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/digest.go
+++ b/pkg/storage/digest.go
@@ -1,55 +1,40 @@
 package storage
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-
-	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
-
 	"google.golang.org/protobuf/proto"
 
+	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 )
 
-// EmptyDigest is a REv2 Digest representing an object of size 0 hashed
-// with SHA256
-var EmptyDigest = &remoteexecution.Digest{
-	Hash:      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-	SizeBytes: 0,
+// ProtoSerialise serialises an arbitrary protobuf into a buffer containing its
+// wire format and a Digest computed using the passed digestFunction.  This is
+// handy for interfacing with REAPI via other Buildbarn APIs.
+func ProtoSerialise(pb proto.Message, digestFunction digest.Function) (buffer.Buffer, digest.Digest, error) {
+	buf := buffer.NewProtoBufferFromProto(pb, buffer.UserProvided)
+
+	sizeBytes, err := buf.GetSizeBytes()
+	if err != nil {
+		return nil, digest.Digest{}, err
+	}
+
+	raw, err := buf.ToByteSlice(int(sizeBytes))
+	if err != nil {
+		return nil, digest.Digest{}, err
+	}
+
+	digestGenerator := digestFunction.NewGenerator(sizeBytes)
+	// TODO: Ensure we write the full buffer
+	_, err = digestGenerator.Write(raw)
+	if err != nil {
+		return nil, digest.Digest{}, err
+	}
+
+	return buf, digestGenerator.Sum(), nil
 }
 
-// ProtoSerialise serialises an arbitrary protobuf message into its wire format and
-// a Remote Execution API Digest of the format.  This is very useful for interacting
-// with the Remote Execution API
-func ProtoSerialise(pb proto.Message) ([]byte, *remoteexecution.Digest, error) {
-	wireFormat, err := proto.Marshal(pb)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	hash := sha256.Sum256(wireFormat)
-
-	return wireFormat,
-		&remoteexecution.Digest{
-			Hash:      hex.EncodeToString(hash[:]),
-			SizeBytes: int64(len(wireFormat)),
-		}, nil
-}
-
-// ProtoToDigest converts an arbitrary protobuf message into a Buildbarn-internal
-// Digest of its content.
-func ProtoToDigest(pb proto.Message, instance digest.InstanceName) (digest.Digest, error) {
-	_, reapiDigest, err := ProtoSerialise(pb)
-	if err != nil {
-		return digest.Digest{}, err
-	}
-	digestFunction, err := instance.GetDigestFunction(remoteexecution.DigestFunction_UNKNOWN, len(reapiDigest.GetHash()))
-	if err != nil {
-		return digest.Digest{}, err
-	}
-	bbDigest, err := digestFunction.NewDigestFromProto(reapiDigest)
-	if err != nil {
-		return digest.Digest{}, err
-	}
-	return bbDigest, nil
+// EmptyDigest produces the empty digest for the given DigestFunction
+func EmptyDigest(digestFunction digest.Function) digest.Digest {
+	generator := digestFunction.NewGenerator(int64(0))
+	return generator.Sum()
 }


### PR DESCRIPTION
The Remote Asset API now includes parameters for the digest function used everywhere, which allows us to correct a lot of our usage.  This PR handles all of that correction.  I've made some API changes to the Asset store, so that we can pass `digest.Function` around instead of `digest.InstanceName`, which simplifies computing digests everywhere.  As part of that, I've also removed a load of cruft we had using the REAPI objects directly instead of the nice digest/buffer APIs from bb-storage.

The HTTP fetcher required an additional bit of work to extricate our handling of the `checksum.sri` validator.  Before the API allowed specifying an digest function, we used this to work out which digest function to use.  This is now incorrect, and will try to do unexpected things, especially in the case you're using an Action Cache Asset Store.  The behaviour is now corrected to only use `checksum.sri` to validate.  In future we should handle the checksum generically on the returned `Digest`, rather than only in the HTTP fetcher.

Fixes #54 

Depends on #56 