### PR TITLE
Leave volatile qualifiers out of asset store digest

### DIFF
--- a/pkg/fetch/caching_fetcher.go
+++ b/pkg/fetch/caching_fetcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"strings"
 
 	"github.com/buildbarn/bb-remote-asset/pkg/proto/asset"
 	"github.com/buildbarn/bb-remote-asset/pkg/qualifier"
@@ -50,7 +51,7 @@ func (cf *cachingFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchB
 
 	// Check assetStore
 	for _, uri := range req.Uris {
-		assetData, err := getAndCheckAsset(ctx, cf.assetStore, uri, req.Qualifiers, digestFunction, oldestContentAccepted)
+		assetData, err := getAndCheckAsset(ctx, cf.assetStore, uri, removeVolatileQualifiers(req.Qualifiers), digestFunction, oldestContentAccepted)
 		if err != nil {
 			allCachingErrors = append(allCachingErrors, err)
 			continue
@@ -82,7 +83,7 @@ func (cf *cachingFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchB
 	}
 
 	// Cache fetched blob with single URI
-	assetRef := storage.NewAssetReference([]string{response.Uri}, response.Qualifiers)
+	assetRef := storage.NewAssetReference([]string{response.Uri}, removeVolatileQualifiers(response.Qualifiers))
 	assetData := storage.NewBlobAsset(response.BlobDigest, getDefaultTimestamp())
 	err = cf.assetStore.Put(ctx, assetRef, assetData, digestFunction)
 	if err != nil {
@@ -133,6 +134,21 @@ func getAndCheckAsset(
 	return assetData, nil
 }
 
+func removeVolatileQualifiers(qualifiers []*remoteasset.Qualifier) []*remoteasset.Qualifier {
+	// Remove qualifiers that are volatile, like auth headers which may change frequently.
+	var stableQualifiers []*remoteasset.Qualifier
+	for _, qualifier := range qualifiers {
+		if strings.HasPrefix(qualifier.Name, "http_header_url:") {
+			continue
+		}
+		if qualifier.Name == "bazel.auth_headers" {
+			continue
+		}
+		stableQualifiers = append(stableQualifiers, qualifier)
+	}
+	return stableQualifiers
+}
+
 func (cf *cachingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.FetchDirectoryRequest) (*remoteasset.FetchDirectoryResponse, error) {
 	digestFunction, err := getDigestFunction(req.DigestFunction, req.InstanceName)
 	if err != nil {
@@ -148,7 +164,7 @@ func (cf *cachingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.F
 
 	// Check refStore
 	for _, uri := range req.Uris {
-		assetData, err := getAndCheckAsset(ctx, cf.assetStore, uri, req.Qualifiers, digestFunction, oldestContentAccepted)
+		assetData, err := getAndCheckAsset(ctx, cf.assetStore, uri, removeVolatileQualifiers(req.Qualifiers), digestFunction, oldestContentAccepted)
 		if err != nil {
 			allCachingErrors = append(allCachingErrors, err)
 			continue
@@ -177,7 +193,7 @@ func (cf *cachingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.F
 	}
 
 	// Cache fetched blob with single URI
-	assetRef := storage.NewAssetReference([]string{response.Uri}, response.Qualifiers)
+	assetRef := storage.NewAssetReference([]string{response.Uri}, removeVolatileQualifiers(response.Qualifiers))
 	assetData := storage.NewDirectoryAsset(response.RootDirectoryDigest, getDefaultTimestamp())
 	err = cf.assetStore.Put(ctx, assetRef, assetData, digestFunction)
 	if err != nil {

--- a/pkg/fetch/caching_fetcher_test.go
+++ b/pkg/fetch/caching_fetcher_test.go
@@ -223,3 +223,215 @@ func TestCachingFetcherOldestContentAccepted(t *testing.T) {
 	require.Contains(t, errAsStatus.Message(), "Asset older than")
 	require.Equal(t, errAsStatus.Code(), codes.NotFound)
 }
+
+func TestFetchBlobVolatileQualifiersIgnored(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	uri := "https://example.com/blob.tar.gz"
+
+	req1 := &remoteasset.FetchBlobRequest{
+		InstanceName: "",
+		Uris:         []string{uri},
+		Qualifiers: []*remoteasset.Qualifier{
+			{Name: "checksum.sri", Value: "sha256-aaa"},
+			{Name: "http_header_url:0:Authorization", Value: "Bearer first"},
+			{Name: "bazel.auth_headers", Value: "token‑one"},
+		},
+	}
+
+	// 2nd request differs only in auth headers.
+	req2 := proto.Clone(req1).(*remoteasset.FetchBlobRequest)
+	req2.Qualifiers[1].Value = "Bearer second"
+	req2.Qualifiers[2].Value = "token‑two"
+
+	// 3rd request differs in non-auth headers and should be a cache miss from the first.
+	req3 := proto.Clone(req1).(*remoteasset.FetchBlobRequest)
+	req3.Qualifiers[0].Value = "Windows"
+
+	blobDigest := &remoteexecution.Digest{
+		Hash:      "1111111111111111111111111111111111111111111111111111111111111111",
+		SizeBytes: 42,
+	}
+
+	backend := mock.NewMockBlobAccess(ctrl)
+	assetStore := storage.NewBlobAccessAssetStore(backend, 16*1024*1024)
+	mockFetcher := mock.NewMockFetcher(ctrl)
+	cachingFetcher := fetch.NewCachingFetcher(mockFetcher, assetStore)
+
+	// 1st fetch is a cache miss, and we'll record the digest used.
+	var firstDigest bb_digest.Digest
+	getMiss := backend.
+		EXPECT().
+		Get(ctx, gomock.Any()).
+		Do(func(_ context.Context, d bb_digest.Digest) {
+                firstDigest = d
+        }).
+		Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "miss")))
+	mockFetcher.
+		EXPECT().
+		FetchBlob(ctx, req1).
+		After(getMiss).
+		Return(&remoteasset.FetchBlobResponse{
+			Status:     status.New(codes.OK, "fetched").Proto(),
+			Uri:        uri,
+			BlobDigest: blobDigest,
+			Qualifiers: req1.Qualifiers,
+		}, nil)
+	backend.
+		EXPECT().
+		Put(ctx, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, d bb_digest.Digest, b buffer.Buffer) error {
+			require.Equal(t, firstDigest, d)
+			return nil
+		})
+
+
+	_, err := cachingFetcher.FetchBlob(ctx, req1)
+	require.NoError(t, err)
+
+	// 2nd fetch should be a cache hit, despite the auth qualifiers being different.
+	backend.
+		EXPECT().
+		Get(ctx, firstDigest).
+		Return(buffer.NewProtoBufferFromProto(storage.NewBlobAsset(blobDigest, nil), buffer.UserProvided))
+
+	_, err = cachingFetcher.FetchBlob(ctx, req2)
+	require.NoError(t, err)
+
+	// 3rd fetch should be a cache miss since non-auth qualifiers differ.
+	var thirdDigest bb_digest.Digest
+	getMiss = backend.
+		EXPECT().
+		Get(ctx, gomock.Any()).
+		Do(func(_ context.Context, d bb_digest.Digest) {
+			require.NotEqual(t, firstDigest, d)
+			thirdDigest = d
+		}).
+		Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "miss")))
+	mockFetcher.
+		EXPECT().
+		FetchBlob(ctx, req3).
+		After(getMiss).
+		Return(&remoteasset.FetchBlobResponse{
+			Status:     status.New(codes.OK, "fetched").Proto(),
+			Uri:        uri,
+			BlobDigest: blobDigest,
+			Qualifiers: req3.Qualifiers,
+		}, nil)
+	backend.
+		EXPECT().
+		Put(ctx, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, d bb_digest.Digest, b buffer.Buffer) error {
+			require.Equal(t, thirdDigest, d)
+			return nil
+		})
+	_, err = cachingFetcher.FetchBlob(ctx, req3)
+	require.NoError(t, err)
+}
+
+
+func TestFetchDirectoryVolatileQualifiersIgnored(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	uri := "https://example.com/dir.zip"
+
+	req1 := &remoteasset.FetchDirectoryRequest{
+		InstanceName: "",
+		Uris:         []string{uri},
+		Qualifiers: []*remoteasset.Qualifier{
+			{Name: "checksum.sri", Value: "sha256-aaa"},
+			{Name: "http_header_url:0:Authorization", Value: "application/zip"},
+			{Name: "bazel.auth_headers", Value: "token‑A"},
+		},
+	}
+
+
+	// 2nd request differs only in auth headers.
+	req2 := proto.Clone(req1).(*remoteasset.FetchDirectoryRequest)
+	req2.Qualifiers[1].Value = "Bearer second"
+	req2.Qualifiers[2].Value = "token‑two"
+
+	// 3rd request differs in non-auth headers and should be a cache miss from the first.
+	req3 := proto.Clone(req1).(*remoteasset.FetchDirectoryRequest)
+	req3.Qualifiers[0].Value = "Windows"
+
+	dirDigest := &remoteexecution.Digest{
+		Hash:      "2222222222222222222222222222222222222222222222222222222222222222",
+		SizeBytes: 99,
+	}
+
+	backend := mock.NewMockBlobAccess(ctrl)
+	assetStore := storage.NewBlobAccessAssetStore(backend, 16*1024*1024)
+	mockFetcher := mock.NewMockFetcher(ctrl)
+	cachingFetcher := fetch.NewCachingFetcher(mockFetcher, assetStore)
+
+	// 1st fetch is a cache miss, and we'll record the digest used.
+	var firstDigest bb_digest.Digest
+	getMiss := backend.
+		EXPECT().
+		Get(ctx, gomock.Any()).
+		Do(func(_ context.Context, d bb_digest.Digest) {
+                firstDigest = d
+        }).
+		Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "miss")))
+	mockFetcher.
+		EXPECT().
+		FetchDirectory(ctx, req1).
+		After(getMiss).
+		Return(&remoteasset.FetchDirectoryResponse{
+			Status:              status.New(codes.OK, "fetched").Proto(),
+			Uri:                 uri,
+			RootDirectoryDigest: dirDigest,
+			Qualifiers: req1.Qualifiers,
+		}, nil)
+	backend.
+		EXPECT().
+		Put(ctx, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, d bb_digest.Digest, b buffer.Buffer) error {
+			require.Equal(t, firstDigest, d)
+			return nil
+		})
+
+
+	_, err := cachingFetcher.FetchDirectory(ctx, req1)
+	require.NoError(t, err)
+
+	// 2nd fetch should be a cache hit, despite the auth qualifiers being different.
+	backend.
+		EXPECT().
+		Get(ctx, firstDigest).
+		Return(buffer.NewProtoBufferFromProto(storage.NewBlobAsset(dirDigest, nil), buffer.UserProvided))
+
+	_, err = cachingFetcher.FetchDirectory(ctx, req2)
+	require.NoError(t, err)
+
+	// 3rd fetch should be a cache miss since non-auth qualifiers differ.
+	var thirdDigest bb_digest.Digest
+	getMiss = backend.
+		EXPECT().
+		Get(ctx, gomock.Any()).
+		Do(func(_ context.Context, d bb_digest.Digest) {
+			require.NotEqual(t, firstDigest, d)
+			thirdDigest = d
+		}).
+		Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "miss")))
+	mockFetcher.
+		EXPECT().
+		FetchDirectory(ctx, req3).
+		After(getMiss).
+		Return(&remoteasset.FetchDirectoryResponse{
+			Status:              status.New(codes.OK, "fetched").Proto(),
+			Uri:                 uri,
+			RootDirectoryDigest: dirDigest,
+			Qualifiers: req3.Qualifiers,
+		}, nil)
+	backend.
+		EXPECT().
+		Put(ctx, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, d bb_digest.Digest, b buffer.Buffer) error {
+			require.Equal(t, thirdDigest, d)
+			return nil
+		})
+	_, err = cachingFetcher.FetchDirectory(ctx, req3)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes https://github.com/buildbarn/bb-remote-asset/issues/60

When the remote asset API is used with Bazel as a client, and `--experimental_remote_downloader_propagate_credentials` is provided, the bearer tokens are included as qualifiers, however since these change regularly and frequently, resources requiring auth not only rarely get cache hits, but also they result in identical copies of their resources populating the asset store cache.

Fix by filtering out auth and http header qualifiers before sending the asset ref down to the asset store.

Note that I'm looking at this PR from my own personal narrow perspective and might be overlooking a subtle detail/requirement... Other solutions I can think of would be to make the digest based entirely on `checksum.sri` if that qualifier is provided, being more specific to include only `http_header_url:*:Authorization` instead of `http_header_url:*` qualifiers, or making this a configuration parameter. 

Also apologies if I missed it but I couldn't find contribution instructions so feel free to point me to them if things need to be fixed up.