### PR TITLE
fetcher: Reject requests without any checksum

### DIFF
--- a/pkg/fetch/logging_fetcher.go
+++ b/pkg/fetch/logging_fetcher.go
@@ -24,9 +24,9 @@ func (lf *loggingFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchB
 	log.Printf("Fetching Blob %s with qualifiers %s", req.Uris, req.Qualifiers)
 	resp, err := lf.fetcher.FetchBlob(ctx, req)
 	if err == nil {
-		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, resp.Status.GetCode())
+		log.Printf("FetchBlob completed for %s with status %v:", req.Uris, resp.Status.String())
 	} else {
-		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, status.Code(err))
+		log.Printf("FetchBlob completed for %s with status: %v", req.Uris, err)
 	}
 	return resp, err
 }
@@ -35,9 +35,9 @@ func (lf *loggingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.F
 	log.Printf("Fetching Directory %s with qualifiers %s", req.Uris, req.Qualifiers)
 	resp, err := lf.fetcher.FetchDirectory(ctx, req)
 	if err == nil {
-		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, resp.Status.GetCode())
+		log.Printf("FetchDirectory completed for %s with status code %d", req.Uris, resp.Status.GetCode())
 	} else {
-		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, status.Code(err))
+		log.Printf("FetchDirectory completed for %s with status code %d", req.Uris, status.Code(err))
 	}
 	return resp, err
 }

--- a/pkg/fetch/validating_fetcher.go
+++ b/pkg/fetch/validating_fetcher.go
@@ -29,6 +29,9 @@ func (vf *validatingFetcher) FetchBlob(ctx context.Context, req *remoteasset.Fet
 	if len(req.Uris) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "FetchBlob does not support requests without any URIs specified.")
 	}
+	if len(req.Qualifiers) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "FetchBlob does not support requests without any Qualifiers specified.")
+	}
 	if unsupported := vf.CheckQualifiers(qualifier.QualifiersToSet(req.Qualifiers)); !(unsupported.IsEmpty()) {
 		violations := []*errdetails.BadRequest_FieldViolation{}
 		for q := range unsupported {

--- a/pkg/fetch/validating_fetcher_test.go
+++ b/pkg/fetch/validating_fetcher_test.go
@@ -24,24 +24,24 @@ func TestFetchBlobUriRequirement(t *testing.T) {
 	request := &remoteasset.FetchBlobRequest{
 		InstanceName: "",
 		Uris:         []string{uri},
+		Qualifiers:   []*remoteasset.Qualifier{{Name: "foo", Value: "bar"}},
 	}
 	badRequest := &remoteasset.FetchBlobRequest{
 		InstanceName: "",
 		Uris:         []string{},
 	}
 	mockFetcher := mock.NewMockFetcher(ctrl)
-
 	validatingFetcher := fetch.NewValidatingFetcher(mockFetcher)
 
 	t.Run("Success", func(t *testing.T) {
-		mockFetcher.EXPECT().CheckQualifiers(qualifier.Set{}).Return(qualifier.Set{})
+		mockFetcher.EXPECT().CheckQualifiers(qualifier.Set{"foo": {}}).Return(qualifier.Set{})
 		mockFetcher.EXPECT().FetchBlob(ctx, request).Return(&remoteasset.FetchBlobResponse{
 			Status:     status.New(codes.OK, "Success!").Proto(),
 			Uri:        uri,
 			BlobDigest: &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123},
 		}, nil)
 		response, err := validatingFetcher.FetchBlob(ctx, request)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, response.Status.Code, int32(codes.OK))
 	})
 


### PR DESCRIPTION
No checksum being sent which means that the
request is not guaranteed reproducible. Bazel's downloader can be used as a general general purpose GET client, and many rulesets abuse this (rules_oci notably) to fetch things like credentials and things that are not reproducible and are dangerous to cache.

However, these things generally lack any checksum (as they downloading dynamic content), so if we require all asset fetch requests to have a checksum, we can filter out these requests and allow the user to have the option to fallback to the local downloader for these requests.

Otherwise, we will cache these, which is wrong.