### PR TITLE
Bound HTTP fetcher memory use under load

### DIFF
--- a/pkg/configuration/new_fetcher.go
+++ b/pkg/configuration/new_fetcher.go
@@ -39,7 +39,8 @@ func NewFetcherFromConfiguration(configuration *pb.FetcherConfiguration,
 			}
 			fetcher = fetch.NewHTTPFetcher(
 				&http.Client{Transport: roundTripper},
-				contentAddressableStorage)
+				contentAddressableStorage,
+				backend.Http.GetDownloadDirectoryPath())
 		case *pb.FetcherConfiguration_Error:
 			fetcher = fetch.NewErrorFetcher(backend.Error)
 		case *pb.FetcherConfiguration_RemoteExecution:

--- a/pkg/fetch/http_fetcher.go
+++ b/pkg/fetch/http_fetcher.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -37,16 +38,23 @@ const (
 type httpFetcher struct {
 	httpClient                *http.Client
 	contentAddressableStorage blobstore.BlobAccess
+	downloadDirectory         string
 }
 
 // NewHTTPFetcher creates a remoteasset FetchServer compatible service for handling requests which involve downloading
 // assets over HTTP and storing them into a CAS.
+//
+// downloadDirectory selects how blobs that can't be streamed directly to the
+// CAS are handled: an empty string buffers them in memory (the default); a
+// non-empty string buffers them in a temporary file in that directory.
 func NewHTTPFetcher(httpClient *http.Client,
 	contentAddressableStorage blobstore.BlobAccess,
+	downloadDirectory string,
 ) Fetcher {
 	return &httpFetcher{
 		httpClient:                httpClient,
 		contentAddressableStorage: contentAddressableStorage,
+		downloadDirectory:         downloadDirectory,
 	}
 }
 
@@ -70,17 +78,21 @@ func (hf *httpFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchBlob
 	}
 
 	for _, uri := range req.Uris {
-		buffer, digest := hf.downloadBlob(ctx, uri, digestFunction, auth)
+		buffer, digest, checksum := hf.downloadBlob(ctx, uri, digestFunction, checksumFunction, expectedDigest, auth)
 		if _, err = buffer.GetSizeBytes(); err != nil {
 			log.Printf("Error downloading blob with URI %s: %v", uri, err)
 			continue
 		}
 
-		// Check the checksum.sri qualifier, if there's an expected Digest
-		if expectedDigest != "" {
-			if ok, err := validateChecksumSri(buffer, checksumFunction, expectedDigest); !ok {
-				return nil, err
-			}
+		// Validate the checksum.sri qualifier. For buffered downloads checksum is
+		// the hash computed while reading, so a mismatch is caught here. For the
+		// fast path where we store in the CAS, checksum equals the expected hash
+		// (the digest is derived from it), making this a no-op; a mismatch there
+		// instead surfaces from the Put below as bb-storage's
+		// "Buffer has checksum ...".
+		if expectedDigest != "" && checksum != expectedDigest {
+			buffer.Discard()
+			return nil, status.Errorf(codes.Internal, "Fetched content did not match checksum.sri qualifier: Expected %s, Got %s", expectedDigest, checksum)
 		}
 
 		if err = hf.contentAddressableStorage.Put(ctx, digest, buffer); err != nil {
@@ -112,35 +124,13 @@ func (hf *httpFetcher) CheckQualifiers(qualifiers qualifier.Set) qualifier.Set {
 	return qualifier.Difference(qualifiers, toRemove)
 }
 
-// validateChecksumSri ensures that the checksum of the passed response matches the expected value.
-func validateChecksumSri(buf buffer.Buffer, checksumFunction bb_digest.Function, expectedDigest string) (bool, error) {
-	sizeBytes, err := buf.GetSizeBytes()
-	if err != nil {
-		return false, err
-	}
-	checksumGenerator := checksumFunction.NewGenerator(sizeBytes)
-	written, err := io.Copy(checksumGenerator, buf.ToReader())
-	if err != nil {
-		return false, err
-	}
-	if written != sizeBytes {
-		return false, status.Errorf(codes.Internal, "Failed to hash entire buffer")
-	}
-
-	checksum := checksumGenerator.Sum().GetProto().GetHash()
-	if checksum != expectedDigest {
-		return false, status.Errorf(codes.Internal, "Fetched content did not match checksum.sri qualifier: Expected %s, Got %s", expectedDigest, checksum)
-	}
-
-	return true, nil
-}
-
-// downloadBlob performs the actual blob download, yielding a buffer of the content and its Digest
-func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, digestFunction bb_digest.Function, auth *AuthHeaders) (buffer.Buffer, bb_digest.Digest) {
+// downloadBlob downloads the blob at uri, returning a Buffer of the content,
+// its Digest, and the content's checksum.sri when expectedChecksum is set.
+func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, digestFunction, checksumFunction bb_digest.Function, expectedChecksum string, auth *AuthHeaders) (buffer.Buffer, bb_digest.Digest, string) {
 	// Generate the HTTP Request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to create HTTP request")), bb_digest.BadDigest
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to create HTTP request")), bb_digest.BadDigest, ""
 	}
 	if auth != nil {
 		auth.ApplyHeaders(uri, req)
@@ -150,27 +140,99 @@ func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, digestFunct
 	resp, err := hf.httpClient.Do(req)
 	if err != nil {
 		log.Printf("Error downloading blob with URI %s: %v", uri, err)
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "HTTP request failed")), bb_digest.BadDigest
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "HTTP request failed")), bb_digest.BadDigest, ""
 	}
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("Error downloading blob with URI %s: %v", uri, resp.StatusCode)
-		return buffer.NewBufferFromError(status.Errorf(codes.Internal, "HTTP request failed with status %#v", resp.Status)), bb_digest.BadDigest
+		return buffer.NewBufferFromError(status.Errorf(codes.Internal, "HTTP request failed with status %#v", resp.Status)), bb_digest.BadDigest, ""
 	}
 
-	// Compute the Digest
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to read response body")), bb_digest.BadDigest
+	// If the digest and size are known, and the checksum.sri method uses the
+	// request's digest function (so its hash IS the CAS hash) we can stream
+	// straight to the CAS, validating the content as the Buffer is read.
+	if expectedChecksum != "" && checksumFunction.GetEnumValue() == digestFunction.GetEnumValue() && resp.ContentLength >= 0 {
+		if digest, err := digestFunction.NewDigest(expectedChecksum, resp.ContentLength); err == nil {
+			return buffer.NewCASBufferFromReader(digest, resp.Body, buffer.UserProvided), digest, expectedChecksum
+		}
 	}
-	err = resp.Body.Close()
-	if err != nil {
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to close response body")), bb_digest.BadDigest
-	}
-	hasher := digestFunction.NewGenerator(resp.ContentLength)
-	hasher.Write(bodyBytes)
-	digest := hasher.Sum()
 
-	return buffer.NewCASBufferFromByteSlice(digest, bodyBytes, buffer.UserProvided), digest
+	// Otherwise the body must be read in full to compute the digest. Buffer
+	// the content either in memory or on disk, hashing as we go.
+	digestGenerator := digestFunction.NewGenerator(resp.ContentLength)
+	var hashes io.Writer = digestGenerator
+	var checksumGenerator *bb_digest.Generator
+	if expectedChecksum != "" {
+		checksumGenerator = checksumFunction.NewGenerator(resp.ContentLength)
+		hashes = io.MultiWriter(digestGenerator, checksumGenerator)
+	}
+	body := io.TeeReader(resp.Body, hashes)
+
+	var buf buffer.Buffer
+	if hf.downloadDirectory != "" {
+		buf, err = bufferBlobOnDisk(hf.downloadDirectory, body)
+	} else {
+		buf, err = bufferBlobInMemory(body)
+	}
+	if err != nil {
+		resp.Body.Close()
+		return buffer.NewBufferFromError(err), bb_digest.BadDigest, ""
+	}
+	if err := resp.Body.Close(); err != nil {
+		buf.Discard()
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to close response body")), bb_digest.BadDigest, ""
+	}
+
+	checksum := ""
+	if checksumGenerator != nil {
+		checksum = checksumGenerator.Sum().GetProto().GetHash()
+	}
+	return buf, digestGenerator.Sum(), checksum
+}
+
+// bufferBlobInMemory reads r fully into memory and returns a Buffer over the bytes.
+func bufferBlobInMemory(r io.Reader) (buffer.Buffer, error) {
+	bodyBytes, err := io.ReadAll(r)
+	if err != nil {
+		return nil, util.StatusWrapWithCode(err, codes.Internal, "Failed to read response body")
+	}
+	// downloadBlob computes the digest from these same bytes, so bodyBytes
+	// already matches it; a validated buffer avoids re-hashing it on upload.
+	return buffer.NewValidatedBufferFromByteSlice(bodyBytes), nil
+}
+
+// removeOnCloseFile is a temporary file whose Close() also removes it from
+// disk, used to back a Buffer with a download buffered on disk.
+type removeOnCloseFile struct {
+	*os.File
+}
+
+func (f *removeOnCloseFile) Close() error {
+	err := f.File.Close()
+	removeErr := os.Remove(f.File.Name())
+	if err != nil {
+		return err
+	}
+	return removeErr
+}
+
+// bufferBlobOnDisk writes r to a temporary file in dir and returns a Buffer
+// backed by that file.
+func bufferBlobOnDisk(dir string, r io.Reader) (buffer.Buffer, error) {
+	f, err := os.CreateTemp(dir, "bb-remote-asset-download-*")
+	if err != nil {
+		return nil, util.StatusWrapWithCode(err, codes.Internal, "Failed to create temporary file for download")
+	}
+	tmpFile := &removeOnCloseFile{File: f}
+	sizeBytes, err := io.Copy(tmpFile, r)
+	if err != nil {
+		// On success the returned Buffer owns tmpFile; here it doesn't, so
+		// close it to remove the partially-written file.
+		tmpFile.Close()
+		return nil, util.StatusWrapWithCode(err, codes.Internal, "Failed to read response body")
+	}
+	// downloadBlob computes the digest from these same bytes, so the file
+	// already matches it; a validated buffer avoids re-hashing it on upload.
+	return buffer.NewValidatedBufferFromReaderAt(tmpFile, sizeBytes), nil
 }
 
 // getChecksumSri parses the checksum.sri qualifier into an expected digest and a digest function to use

--- a/pkg/fetch/http_fetcher_test.go
+++ b/pkg/fetch/http_fetcher_test.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
+	"testing/iotest"
 
 	"github.com/buildbarn/bb-remote-asset/internal/mock"
 	"github.com/buildbarn/bb-remote-asset/pkg/fetch"
 	"github.com/buildbarn/bb-remote-asset/pkg/qualifier"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
 	"github.com/buildbarn/bb-storage/pkg/util"
@@ -59,6 +62,14 @@ const InstanceName = ""
 // Data used as the blob
 const TestData = "Hello"
 
+// consumePut mimics a real BlobAccess.Put: it reads the buffer to completion,
+// validating the content (as the fast path's in-stream check does) and
+// releasing the body/temporary file that would otherwise leak in these mocked tests.
+func consumePut(_ context.Context, _ digest.Digest, b buffer.Buffer) error {
+	_, err := b.ToByteSlice(1 << 20)
+	return err
+}
+
 // Convert DigestFunction Enum to strings
 var HashNames = map[remoteexecution.DigestFunction_Value]string{
 	remoteexecution.DigestFunction_SHA256:     "sha256",
@@ -75,104 +86,188 @@ func digestToChecksumSri(df remoteexecution.DigestFunction_Value, d digest.Diges
 	return fmt.Sprintf("%s-%s", HashNames[df], base64.StdEncoding.EncodeToString(d.GetHashBytes()))
 }
 
-func TestHTTPFetcherFetchBlobSuccessSHA256(t *testing.T) {
-	testHTTPFetcherFetchBlobSuccessWithHasher(
-		t,
+// TestHTTPFetcherFetchBlobFastPathDigestFunctions checks the direct-streaming
+// fast path for every checksum.sri digest function: the response is streamed
+// straight to the CAS under a digest derived from the checksum.
+func TestHTTPFetcherFetchBlobFastPathDigestFunctions(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	for _, digestFunctionEnum := range []remoteexecution.DigestFunction_Value{
 		remoteexecution.DigestFunction_SHA256,
-	)
-}
-
-func TestHTTPFetcherFetchBlobSuccessSHA1(t *testing.T) {
-	testHTTPFetcherFetchBlobSuccessWithHasher(
-		t,
 		remoteexecution.DigestFunction_SHA1,
-	)
-}
-
-func TestHTTPFetcherFetchBlobSuccessMD5(t *testing.T) {
-	testHTTPFetcherFetchBlobSuccessWithHasher(
-		t,
 		remoteexecution.DigestFunction_MD5,
-	)
-}
-
-func TestHTTPFetcherFetchBlobSuccessSHA384(t *testing.T) {
-	testHTTPFetcherFetchBlobSuccessWithHasher(
-		t,
 		remoteexecution.DigestFunction_SHA384,
-	)
-}
-
-func TestHTTPFetcherFetchBlobSuccessSHA512(t *testing.T) {
-	testHTTPFetcherFetchBlobSuccessWithHasher(
-		t,
 		remoteexecution.DigestFunction_SHA512,
-	)
-}
-
-func TestHTTPFetcherFetchBlobSuccessSha256tree(t *testing.T) {
-	testHTTPFetcherFetchBlobSuccessWithHasher(
-		t,
 		remoteexecution.DigestFunction_SHA256TREE,
-	)
+	} {
+		t.Run(digestFunctionEnum.String(), func(t *testing.T) {
+			instance := util.Must(digest.NewInstanceName(InstanceName))
+			digestFunction, err := instance.GetDigestFunction(digestFunctionEnum, 0)
+			require.NoError(t, err)
+			digestGenerator := digestFunction.NewGenerator(int64(len(TestData)))
+			digestGenerator.Write([]byte(TestData))
+			helloDigest := digestGenerator.Sum()
+
+			casBlobAccess := mock.NewMockBlobAccess(ctrl)
+			roundTripper := mock.NewMockRoundTripper(ctrl)
+			HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, "")
+
+			request := &remoteasset.FetchBlobRequest{
+				InstanceName:   InstanceName,
+				Uris:           []string{"www.example.com"},
+				Qualifiers:     []*remoteasset.Qualifier{{Name: "checksum.sri", Value: digestToChecksumSri(digestFunctionEnum, helloDigest)}},
+				DigestFunction: digestFunctionEnum,
+			}
+			body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
+			httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+				Status: "200 Success", StatusCode: 200, Body: body, ContentLength: 5,
+			}, nil)
+			casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).DoAndReturn(consumePut).After(httpDoCall)
+
+			response, err := HTTPFetcher.FetchBlob(ctx, request)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
+			require.Equal(t, response.Status.Code, int32(codes.OK))
+		})
+	}
 }
 
-func testHTTPFetcherFetchBlobSuccessWithHasher(t *testing.T, digestFunctionEnum remoteexecution.DigestFunction_Value) {
+// TestHTTPFetcherFetchBlobSuccess checks that each download strategy stores the
+// blob and returns its digest.
+func TestHTTPFetcherFetchBlobSuccess(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 
 	instance := util.Must(digest.NewInstanceName(InstanceName))
-	digestFunction, err := instance.GetDigestFunction(digestFunctionEnum, 0)
+	digestFunction, err := instance.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
+	digestGenerator := digestFunction.NewGenerator(int64(len(TestData)))
+	digestGenerator.Write([]byte(TestData))
+	helloDigest := digestGenerator.Sum()
+	withChecksum := []*remoteasset.Qualifier{{
+		Name:  "checksum.sri",
+		Value: digestToChecksumSri(remoteexecution.DigestFunction_SHA256, helloDigest),
+	}}
+
+	for _, tc := range []struct {
+		name          string
+		onDisk        bool
+		qualifiers    []*remoteasset.Qualifier
+		contentLength int64
+	}{
+		{"DirectStream", false, withChecksum, 5},
+		{"BufferInMemory", false, nil, 5},
+		{"BufferOnDisk", true, nil, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			casBlobAccess := mock.NewMockBlobAccess(ctrl)
+			roundTripper := mock.NewMockRoundTripper(ctrl)
+			var downloadDir string
+			if tc.onDisk {
+				downloadDir = t.TempDir()
+			}
+			HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, downloadDir)
+
+			request := &remoteasset.FetchBlobRequest{
+				InstanceName:   InstanceName,
+				Uris:           []string{"www.example.com"},
+				Qualifiers:     tc.qualifiers,
+				DigestFunction: remoteexecution.DigestFunction_SHA256,
+			}
+			body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
+			httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+				Status: "200 Success", StatusCode: 200, Body: body, ContentLength: tc.contentLength,
+			}, nil)
+			casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).DoAndReturn(consumePut).After(httpDoCall)
+
+			response, err := HTTPFetcher.FetchBlob(ctx, request)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
+			require.Equal(t, response.Status.Code, int32(codes.OK))
+
+			// A blob buffered on disk leaves no temporary file behind once the
+			// Buffer has been consumed.
+			if tc.onDisk {
+				entries, err := os.ReadDir(downloadDir)
+				require.NoError(t, err)
+				require.Empty(t, entries)
+			}
+		})
+	}
+}
+
+// TestHTTPFetcherFetchBlobOnDiskBufferConsumption checks that the file-backed
+// Buffer produced by the on-disk path can be consumed through both ways the CAS
+// consumes it — a chunk reader (plain ByteStream.Write) and a writer
+// (ZSTD-compressed writes) — and that the temporary file is removed in each.
+func TestHTTPFetcherFetchBlobOnDiskBufferConsumption(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	instance := util.Must(digest.NewInstanceName(InstanceName))
+	digestFunction, err := instance.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
 	require.NoError(t, err)
 	digestGenerator := digestFunction.NewGenerator(int64(len(TestData)))
 	digestGenerator.Write([]byte(TestData))
 	helloDigest := digestGenerator.Sum()
 
+	// No checksum.sri and no Content-Length forces an on-disk file-backed Buffer.
 	request := &remoteasset.FetchBlobRequest{
-		InstanceName: InstanceName,
-		Uris:         []string{"www.example.com"},
-		Qualifiers: []*remoteasset.Qualifier{
-			{
-				Name:  "checksum.sri",
-				Value: digestToChecksumSri(digestFunctionEnum, helloDigest),
-			},
-		},
-		DigestFunction: digestFunctionEnum,
+		InstanceName:   InstanceName,
+		Uris:           []string{"www.example.com"},
+		DigestFunction: remoteexecution.DigestFunction_SHA256,
 	}
-	casBlobAccess := mock.NewMockBlobAccess(ctrl)
-	roundTripper := mock.NewMockRoundTripper(ctrl)
-	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess)
 
-	t.Run("Success"+helloDigest.GetDigestFunction().GetEnumValue().String(), func(t *testing.T) {
-		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
-		httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-			Status:        "200 Success",
-			StatusCode:    200,
-			Body:          body,
-			ContentLength: 5,
-		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
+	for _, tc := range []struct {
+		name    string
+		consume func(buffer.Buffer) ([]byte, error)
+	}{
+		{"ChunkReader", func(b buffer.Buffer) ([]byte, error) {
+			r := b.ToChunkReader(0, 2)
+			defer r.Close()
+			var data []byte
+			for {
+				chunk, err := r.Read()
+				data = append(data, chunk...)
+				if err == io.EOF {
+					return data, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+			}
+		}},
+		{"Writer", func(b buffer.Buffer) ([]byte, error) {
+			var w bytes.Buffer
+			err := b.IntoWriter(&w)
+			return w.Bytes(), err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			downloadDir := t.TempDir()
+			casBlobAccess := mock.NewMockBlobAccess(ctrl)
+			roundTripper := mock.NewMockRoundTripper(ctrl)
+			HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, downloadDir)
 
-		response, err := HTTPFetcher.FetchBlob(ctx, request)
-		require.NoError(t, err)
-		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
-		require.Equal(t, response.Status.Code, int32(codes.OK))
-	})
+			body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
+			httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+				Status: "200 Success", StatusCode: 200, Body: body, ContentLength: -1,
+			}, nil)
+			casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ digest.Digest, b buffer.Buffer) error {
+					data, err := tc.consume(b)
+					require.NoError(t, err)
+					require.Equal(t, TestData, string(data))
+					return nil
+				}).After(httpDoCall)
 
-	t.Run("SuccessNoContentLength", func(t *testing.T) {
-		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
-		roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-			Status:        "200 Success",
-			StatusCode:    200,
-			Body:          body,
-			ContentLength: -1,
-		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil)
+			response, err := HTTPFetcher.FetchBlob(ctx, request)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
 
-		response, err := HTTPFetcher.FetchBlob(ctx, request)
-		require.NoError(t, err)
-		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
-		require.Equal(t, response.Status.Code, int32(codes.OK))
-	})
+			entries, err := os.ReadDir(downloadDir)
+			require.NoError(t, err)
+			require.Empty(t, entries)
+		})
+	}
 }
 
 func TestHTTPFetcherFetchBlob(t *testing.T) {
@@ -198,49 +293,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 	}
 	casBlobAccess := mock.NewMockBlobAccess(ctrl)
 	roundTripper := mock.NewMockRoundTripper(ctrl)
-	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess)
-
-	t.Run("SuccessNoExpectedDigest", func(t *testing.T) {
-		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
-		request := &remoteasset.FetchBlobRequest{
-			InstanceName: InstanceName,
-			Uris:         []string{uri, "www.another.com"},
-			Qualifiers:   []*remoteasset.Qualifier{},
-		}
-		httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-			Status:        "200 Success",
-			StatusCode:    200,
-			Body:          body,
-			ContentLength: 5,
-		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
-
-		response, err := HTTPFetcher.FetchBlob(ctx, request)
-		require.NoError(t, err)
-		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
-		require.Equal(t, response.Status.Code, int32(codes.OK))
-	})
-
-	t.Run("SuccessNoExpectedDigestOrContentLength", func(t *testing.T) {
-		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
-		request := &remoteasset.FetchBlobRequest{
-			InstanceName: InstanceName,
-			Uris:         []string{uri, "www.another.com"},
-			Qualifiers:   []*remoteasset.Qualifier{},
-		}
-		httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-			Status:        "200 Success",
-			StatusCode:    200,
-			Body:          body,
-			ContentLength: -1,
-		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
-
-		response, err := HTTPFetcher.FetchBlob(ctx, request)
-		require.NoError(t, err)
-		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
-		require.Equal(t, response.Status.Code, int32(codes.OK))
-	})
+	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, "")
 
 	t.Run("UnknownChecksumSriAlgo", func(t *testing.T) {
 		request := &remoteasset.FetchBlobRequest{
@@ -305,7 +358,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			Body:          body,
 			ContentLength: 5,
 		}, nil).After(httpFailCall)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpSuccessCall)
+		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).DoAndReturn(consumePut).After(httpSuccessCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
@@ -352,7 +405,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			Body:          body,
 			ContentLength: 5,
 		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
+		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).DoAndReturn(consumePut).After(httpDoCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
@@ -408,12 +461,96 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			ContentLength: 5,
 		}, nil)
 
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall2)
+		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).DoAndReturn(consumePut).After(httpDoCall2)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.Nil(t, err)
 		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
 		require.Equal(t, response.Status.Code, int32(codes.OK))
+	})
+}
+
+// TestHTTPFetcherFetchBlobBuffering covers the error and cleanup behaviour of
+// the buffering download paths (i.e. when the blob can't be streamed directly).
+func TestHTTPFetcherFetchBlobBuffering(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	instance := util.Must(digest.NewInstanceName(InstanceName))
+	digestFunction, err := instance.GetDigestFunction(remoteexecution.DigestFunction_SHA256, 0)
+	require.NoError(t, err)
+	digestGenerator := digestFunction.NewGenerator(int64(len(TestData)))
+	digestGenerator.Write([]byte(TestData))
+	helloDigest := digestGenerator.Sum()
+
+	uri := "www.example.com"
+	// No checksum.sri and no Content-Length, so the fast path never applies and
+	// the body is always buffered.
+	request := &remoteasset.FetchBlobRequest{
+		InstanceName:   InstanceName,
+		Uris:           []string{uri},
+		DigestFunction: remoteexecution.DigestFunction_SHA256,
+	}
+
+	t.Run("OnDiskReadErrorRemovesTempFile", func(t *testing.T) {
+		downloadDir := t.TempDir()
+		casBlobAccess := mock.NewMockBlobAccess(ctrl)
+		roundTripper := mock.NewMockRoundTripper(ctrl)
+		HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, downloadDir)
+
+		// The body fails mid-download; no Put should happen, and the partially
+		// written temporary file must be cleaned up.
+		body := io.NopCloser(iotest.ErrReader(fmt.Errorf("connection reset")))
+		roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+			Status: "200 Success", StatusCode: 200, Body: body, ContentLength: -1,
+		}, nil)
+
+		response, err := HTTPFetcher.FetchBlob(ctx, request)
+		require.Nil(t, response)
+		require.Equal(t, codes.NotFound, status.Code(err))
+
+		entries, err := os.ReadDir(downloadDir)
+		require.NoError(t, err)
+		require.Empty(t, entries, "partially written temporary file should have been removed")
+	})
+
+	t.Run("PutFailureReturnsInternal", func(t *testing.T) {
+		casBlobAccess := mock.NewMockBlobAccess(ctrl)
+		roundTripper := mock.NewMockRoundTripper(ctrl)
+		HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, "")
+
+		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
+		httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+			Status: "200 Success", StatusCode: 200, Body: body, ContentLength: -1,
+		}, nil)
+		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(status.Error(codes.Unavailable, "CAS unavailable")).After(httpDoCall)
+
+		response, err := HTTPFetcher.FetchBlob(ctx, request)
+		require.Nil(t, response)
+		require.Equal(t, codes.Internal, status.Code(err))
+	})
+
+	t.Run("ChecksumMismatch", func(t *testing.T) {
+		// checksum.sri present but the body doesn't match it; with no
+		// Content-Length the fast path can't apply, so the mismatch is caught
+		// after buffering.
+		casBlobAccess := mock.NewMockBlobAccess(ctrl)
+		roundTripper := mock.NewMockRoundTripper(ctrl)
+		HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, "")
+
+		request := &remoteasset.FetchBlobRequest{
+			InstanceName:   InstanceName,
+			Uris:           []string{uri},
+			Qualifiers:     []*remoteasset.Qualifier{{Name: "checksum.sri", Value: digestToChecksumSri(remoteexecution.DigestFunction_SHA256, helloDigest)}},
+			DigestFunction: remoteexecution.DigestFunction_SHA256,
+		}
+		body := io.NopCloser(bytes.NewBuffer([]byte("Not the expected content")))
+		roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+			Status: "200 Success", StatusCode: 200, Body: body, ContentLength: -1,
+		}, nil)
+
+		response, err := HTTPFetcher.FetchBlob(ctx, request)
+		require.Nil(t, response)
+		require.Equal(t, codes.Internal, status.Code(err))
 	})
 }
 
@@ -427,7 +564,7 @@ func TestHTTPFetcherFetchDirectory(t *testing.T) {
 	}
 	casBlobAccess := mock.NewMockBlobAccess(ctrl)
 	roundTripper := mock.NewMockRoundTripper(ctrl)
-	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess)
+	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess, "")
 	_, err := HTTPFetcher.FetchDirectory(ctx, request)
 	require.NotNil(t, err)
 	require.Equal(t, status.Code(err), codes.PermissionDenied)

--- a/pkg/proto/configuration/bb_remote_asset/fetch/fetcher.pb.go
+++ b/pkg/proto/configuration/bb_remote_asset/fetch/fetcher.pb.go
@@ -123,10 +123,11 @@ func (*FetcherConfiguration_Error) isFetcherConfiguration_Backend() {}
 func (*FetcherConfiguration_RemoteExecution) isFetcherConfiguration_Backend() {}
 
 type FetcherConfiguration_HttpFetcherConfiguration struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Client        *client.Configuration  `protobuf:"bytes,3,opt,name=client,proto3" json:"client,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Client                *client.Configuration  `protobuf:"bytes,3,opt,name=client,proto3" json:"client,omitempty"`
+	DownloadDirectoryPath string                 `protobuf:"bytes,4,opt,name=download_directory_path,json=downloadDirectoryPath,proto3" json:"download_directory_path,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *FetcherConfiguration_HttpFetcherConfiguration) Reset() {
@@ -164,6 +165,13 @@ func (x *FetcherConfiguration_HttpFetcherConfiguration) GetClient() *client.Conf
 		return x.Client
 	}
 	return nil
+}
+
+func (x *FetcherConfiguration_HttpFetcherConfiguration) GetDownloadDirectoryPath() string {
+	if x != nil {
+		return x.DownloadDirectoryPath
+	}
+	return ""
 }
 
 type FetcherConfiguration_RemoteExecutionFetcherConfiguration struct {
@@ -214,13 +222,14 @@ var File_github_com_buildbarn_bb_remote_asset_pkg_proto_configuration_bb_remote_
 
 const file_github_com_buildbarn_bb_remote_asset_pkg_proto_configuration_bb_remote_asset_fetch_fetcher_proto_rawDesc = "" +
 	"\n" +
-	"`github.com/buildbarn/bb-remote-asset/pkg/proto/configuration/bb_remote_asset/fetch/fetcher.proto\x12-buildbarn.configuration.bb_remote_asset.fetch\x1a\x17google/rpc/status.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\"\xd8\x04\n" +
+	"`github.com/buildbarn/bb-remote-asset/pkg/proto/configuration/bb_remote_asset/fetch/fetcher.proto\x12-buildbarn.configuration.bb_remote_asset.fetch\x1a\x17google/rpc/status.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\"\x91\x05\n" +
 	"\x14FetcherConfiguration\x12r\n" +
 	"\x04http\x18\x02 \x01(\v2\\.buildbarn.configuration.bb_remote_asset.fetch.FetcherConfiguration.HttpFetcherConfigurationH\x00R\x04http\x12*\n" +
 	"\x05error\x18\x03 \x01(\v2\x12.google.rpc.StatusH\x00R\x05error\x12\x94\x01\n" +
-	"\x10remote_execution\x18\x04 \x01(\v2g.buildbarn.configuration.bb_remote_asset.fetch.FetcherConfiguration.RemoteExecutionFetcherConfigurationH\x00R\x0fremoteExecution\x1ar\n" +
+	"\x10remote_execution\x18\x04 \x01(\v2g.buildbarn.configuration.bb_remote_asset.fetch.FetcherConfiguration.RemoteExecutionFetcherConfigurationH\x00R\x0fremoteExecution\x1a\xaa\x01\n" +
 	"\x18HttpFetcherConfiguration\x12J\n" +
-	"\x06client\x18\x03 \x01(\v22.buildbarn.configuration.http.client.ConfigurationR\x06clientJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03\x1a\x83\x01\n" +
+	"\x06client\x18\x03 \x01(\v22.buildbarn.configuration.http.client.ConfigurationR\x06client\x126\n" +
+	"\x17download_directory_path\x18\x04 \x01(\tR\x15downloadDirectoryPathJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03\x1a\x83\x01\n" +
 	"#RemoteExecutionFetcherConfiguration\x12\\\n" +
 	"\x10execution_client\x18\x02 \x01(\v21.buildbarn.configuration.grpc.ClientConfigurationR\x0fexecutionClientB\t\n" +
 	"\abackendJ\x04\b\x01\x10\x02BTZRgithub.com/buildbarn/bb-remote-asset/pkg/proto/configuration/bb_remote_asset/fetchb\x06proto3"

--- a/pkg/proto/configuration/bb_remote_asset/fetch/fetcher.proto
+++ b/pkg/proto/configuration/bb_remote_asset/fetch/fetcher.proto
@@ -48,6 +48,10 @@ message FetcherConfiguration {
 
     // Optional: Options to be used by the HTTP client.
     buildbarn.configuration.http.client.Configuration client = 3;
+
+    // Optional: directory in which downloads that cannot be streamed to CAS
+    // are buffered in a temporary file on disk instead of in memory.
+    string download_directory_path = 4;
   }
 
   message RemoteExecutionFetcherConfiguration {


### PR DESCRIPTION
The HTTP fetcher read each download fully into memory (io.ReadAll) before storing it in the CAS, so large numbers of parallel fetches could cause OOMs.

Two changes address this:
- When the blob's digest is known up front (a checksum.sri using the request's digest function, plus a Content-Length), the response is streamed straight to the CAS without being buffered at all.
- Otherwise the body has to be read to compute the digest. This is still buffered in memory by default, but the new download_directory_path option buffers it in a temporary file on disk instead.

This was written with Claude but I've carefully reviewed it all and tested it end to end locally.