### PR TITLE
Stream HTTP fetches to temporary files

### DIFF
--- a/pkg/fetch/http_fetcher.go
+++ b/pkg/fetch/http_fetcher.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -37,6 +39,23 @@ const (
 type httpFetcher struct {
 	httpClient                *http.Client
 	contentAddressableStorage blobstore.BlobAccess
+}
+
+type temporaryFile struct {
+	*os.File
+}
+
+func (f *temporaryFile) Close() error {
+	path := f.Name()
+	closeErr := f.File.Close()
+	removeErr := os.Remove(path)
+	if closeErr != nil {
+		return closeErr
+	}
+	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return removeErr
+	}
+	return nil
 }
 
 // NewHTTPFetcher creates a remoteasset FetchServer compatible service for handling requests which involve downloading
@@ -70,17 +89,15 @@ func (hf *httpFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchBlob
 	}
 
 	for _, uri := range req.Uris {
-		buffer, digest := hf.downloadBlob(ctx, uri, digestFunction, auth)
+		buffer, digest, checksum := hf.downloadBlob(ctx, uri, digestFunction, checksumFunction, expectedDigest, auth)
 		if _, err = buffer.GetSizeBytes(); err != nil {
 			log.Printf("Error downloading blob with URI %s: %v", uri, err)
 			continue
 		}
 
-		// Check the checksum.sri qualifier, if there's an expected Digest
-		if expectedDigest != "" {
-			if ok, err := validateChecksumSri(buffer, checksumFunction, expectedDigest); !ok {
-				return nil, err
-			}
+		if expectedDigest != "" && checksum != expectedDigest {
+			buffer.Discard()
+			return nil, status.Errorf(codes.Internal, "Fetched content did not match checksum.sri qualifier: Expected %s, Got %s", expectedDigest, checksum)
 		}
 
 		if err = hf.contentAddressableStorage.Put(ctx, digest, buffer); err != nil {
@@ -112,35 +129,12 @@ func (hf *httpFetcher) CheckQualifiers(qualifiers qualifier.Set) qualifier.Set {
 	return qualifier.Difference(qualifiers, toRemove)
 }
 
-// validateChecksumSri ensures that the checksum of the passed response matches the expected value.
-func validateChecksumSri(buf buffer.Buffer, checksumFunction bb_digest.Function, expectedDigest string) (bool, error) {
-	sizeBytes, err := buf.GetSizeBytes()
-	if err != nil {
-		return false, err
-	}
-	checksumGenerator := checksumFunction.NewGenerator(sizeBytes)
-	written, err := io.Copy(checksumGenerator, buf.ToReader())
-	if err != nil {
-		return false, err
-	}
-	if written != sizeBytes {
-		return false, status.Errorf(codes.Internal, "Failed to hash entire buffer")
-	}
-
-	checksum := checksumGenerator.Sum().GetProto().GetHash()
-	if checksum != expectedDigest {
-		return false, status.Errorf(codes.Internal, "Fetched content did not match checksum.sri qualifier: Expected %s, Got %s", expectedDigest, checksum)
-	}
-
-	return true, nil
-}
-
-// downloadBlob performs the actual blob download, yielding a buffer of the content and its Digest
-func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, digestFunction bb_digest.Function, auth *AuthHeaders) (buffer.Buffer, bb_digest.Digest) {
+// downloadBlob performs the actual blob download, yielding a buffer of the content, its Digest, and checksum.
+func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, digestFunction, checksumFunction bb_digest.Function, expectedDigest string, auth *AuthHeaders) (buffer.Buffer, bb_digest.Digest, string) {
 	// Generate the HTTP Request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to create HTTP request")), bb_digest.BadDigest
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to create HTTP request")), bb_digest.BadDigest, ""
 	}
 	if auth != nil {
 		auth.ApplyHeaders(uri, req)
@@ -150,27 +144,56 @@ func (hf *httpFetcher) downloadBlob(ctx context.Context, uri string, digestFunct
 	resp, err := hf.httpClient.Do(req)
 	if err != nil {
 		log.Printf("Error downloading blob with URI %s: %v", uri, err)
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "HTTP request failed")), bb_digest.BadDigest
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "HTTP request failed")), bb_digest.BadDigest, ""
 	}
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("Error downloading blob with URI %s: %v", uri, resp.StatusCode)
-		return buffer.NewBufferFromError(status.Errorf(codes.Internal, "HTTP request failed with status %#v", resp.Status)), bb_digest.BadDigest
+		return buffer.NewBufferFromError(status.Errorf(codes.Internal, "HTTP request failed with status %#v", resp.Status)), bb_digest.BadDigest, ""
 	}
+	defer func() {
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}()
 
-	// Compute the Digest
-	bodyBytes, err := io.ReadAll(resp.Body)
+	tempFileHandle, err := os.CreateTemp("", "bb-remote-asset-*")
 	if err != nil {
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to read response body")), bb_digest.BadDigest
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to create temporary file")), bb_digest.BadDigest, ""
+	}
+	tempFile := &temporaryFile{File: tempFileHandle}
+	shouldCloseTempFile := true
+	defer func() {
+		if shouldCloseTempFile {
+			if err := tempFile.Close(); err != nil {
+				log.Printf("Failed to close temporary file %s: %v", tempFile.Name(), err)
+			}
+		}
+	}()
+
+	// Compute digests while streaming the response body to disk.
+	hasher := digestFunction.NewGenerator(resp.ContentLength)
+	writers := []io.Writer{tempFile, hasher}
+	var checksumGenerator *bb_digest.Generator
+	if expectedDigest != "" {
+		checksumGenerator = checksumFunction.NewGenerator(resp.ContentLength)
+		writers = append(writers, checksumGenerator)
+	}
+	if _, err := io.Copy(io.MultiWriter(writers...), resp.Body); err != nil {
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to read response body")), bb_digest.BadDigest, ""
 	}
 	err = resp.Body.Close()
 	if err != nil {
-		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to close response body")), bb_digest.BadDigest
+		return buffer.NewBufferFromError(util.StatusWrapWithCode(err, codes.Internal, "Failed to close response body")), bb_digest.BadDigest, ""
 	}
-	hasher := digestFunction.NewGenerator(resp.ContentLength)
-	hasher.Write(bodyBytes)
+	resp.Body = nil
 	digest := hasher.Sum()
+	checksum := ""
+	if expectedDigest != "" {
+		checksum = checksumGenerator.Sum().GetProto().GetHash()
+	}
 
-	return buffer.NewCASBufferFromByteSlice(digest, bodyBytes, buffer.UserProvided), digest
+	shouldCloseTempFile = false
+	return buffer.NewValidatedBufferFromReaderAt(tempFile, digest.GetSizeBytes()), digest, checksum
 }
 
 // getChecksumSri parses the checksum.sri qualifier into an expected digest and a digest function to use

--- a/pkg/fetch/http_fetcher_test.go
+++ b/pkg/fetch/http_fetcher_test.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/buildbarn/bb-remote-asset/internal/mock"
 	"github.com/buildbarn/bb-remote-asset/pkg/fetch"
 	"github.com/buildbarn/bb-remote-asset/pkg/qualifier"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
 	"github.com/buildbarn/bb-storage/pkg/util"
@@ -73,6 +75,59 @@ var HashNames = map[remoteexecution.DigestFunction_Value]string{
 // df must match the value used by d
 func digestToChecksumSri(df remoteexecution.DigestFunction_Value, d digest.Digest) string {
 	return fmt.Sprintf("%s-%s", HashNames[df], base64.StdEncoding.EncodeToString(d.GetHashBytes()))
+}
+
+func requireBlobBufferContentsFromChunkReader(t *testing.T, blobBuffer buffer.Buffer) {
+	t.Helper()
+
+	chunkReader := blobBuffer.ToChunkReader(0, 2)
+	defer chunkReader.Close()
+
+	var data []byte
+	for {
+		chunk, err := chunkReader.Read()
+		if err == nil {
+			data = append(data, chunk...)
+			continue
+		}
+		require.ErrorIs(t, err, io.EOF)
+		break
+	}
+	require.Equal(t, TestData, string(data))
+}
+
+func requireBlobBufferContentsIntoWriter(t *testing.T, blobBuffer buffer.Buffer) {
+	t.Helper()
+
+	var data bytes.Buffer
+	require.NoError(t, blobBuffer.IntoWriter(&data))
+	require.Equal(t, TestData, data.String())
+}
+
+func requireNoTemporaryFiles(t *testing.T, tempDir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func expectBlobPut(t *testing.T, casBlobAccess *mock.MockBlobAccess, ctx context.Context, blobDigest digest.Digest) *gomock.Call {
+	return casBlobAccess.EXPECT().Put(ctx, blobDigest, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ digest.Digest, blobBuffer buffer.Buffer) error {
+			requireBlobBufferContentsFromChunkReader(t, blobBuffer)
+			return nil
+		},
+	)
+}
+
+func expectBlobPutIntoWriter(t *testing.T, casBlobAccess *mock.MockBlobAccess, ctx context.Context, blobDigest digest.Digest) *gomock.Call {
+	return casBlobAccess.EXPECT().Put(ctx, blobDigest, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ digest.Digest, blobBuffer buffer.Buffer) error {
+			requireBlobBufferContentsIntoWriter(t, blobBuffer)
+			return nil
+		},
+	)
 }
 
 func TestHTTPFetcherFetchBlobSuccessSHA256(t *testing.T) {
@@ -143,6 +198,8 @@ func testHTTPFetcherFetchBlobSuccessWithHasher(t *testing.T, digestFunctionEnum 
 	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess)
 
 	t.Run("Success"+helloDigest.GetDigestFunction().GetEnumValue().String(), func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
 		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
 		httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
 			Status:        "200 Success",
@@ -150,15 +207,18 @@ func testHTTPFetcherFetchBlobSuccessWithHasher(t *testing.T, digestFunctionEnum 
 			Body:          body,
 			ContentLength: 5,
 		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest).After(httpDoCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
 		require.Equal(t, response.Status.Code, int32(codes.OK))
+		requireNoTemporaryFiles(t, tempDir)
 	})
 
 	t.Run("SuccessNoContentLength", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
 		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
 		roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
 			Status:        "200 Success",
@@ -166,12 +226,13 @@ func testHTTPFetcherFetchBlobSuccessWithHasher(t *testing.T, digestFunctionEnum 
 			Body:          body,
 			ContentLength: -1,
 		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
 		require.Equal(t, response.Status.Code, int32(codes.OK))
+		requireNoTemporaryFiles(t, tempDir)
 	})
 }
 
@@ -201,6 +262,8 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 	HTTPFetcher := fetch.NewHTTPFetcher(&http.Client{Transport: roundTripper}, casBlobAccess)
 
 	t.Run("SuccessNoExpectedDigest", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
 		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
 		request := &remoteasset.FetchBlobRequest{
 			InstanceName: InstanceName,
@@ -213,15 +276,18 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			Body:          body,
 			ContentLength: 5,
 		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest).After(httpDoCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
 		require.Equal(t, response.Status.Code, int32(codes.OK))
+		requireNoTemporaryFiles(t, tempDir)
 	})
 
 	t.Run("SuccessNoExpectedDigestOrContentLength", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
 		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
 		request := &remoteasset.FetchBlobRequest{
 			InstanceName: InstanceName,
@@ -234,12 +300,32 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			Body:          body,
 			ContentLength: -1,
 		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest).After(httpDoCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
 		require.Equal(t, response.Status.Code, int32(codes.OK))
+		requireNoTemporaryFiles(t, tempDir)
+	})
+
+	t.Run("SuccessIntoWriter", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
+		body := io.NopCloser(bytes.NewBuffer([]byte(TestData)))
+		httpDoCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+			Status:        "200 Success",
+			StatusCode:    200,
+			Body:          body,
+			ContentLength: 5,
+		}, nil)
+		expectBlobPutIntoWriter(t, casBlobAccess, ctx, helloDigest).After(httpDoCall)
+
+		response, err := HTTPFetcher.FetchBlob(ctx, request)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(response.BlobDigest, helloDigest.GetProto()))
+		require.Equal(t, response.Status.Code, int32(codes.OK))
+		requireNoTemporaryFiles(t, tempDir)
 	})
 
 	t.Run("UnknownChecksumSriAlgo", func(t *testing.T) {
@@ -293,6 +379,34 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 		require.Nil(t, response)
 	})
 
+	t.Run("ChecksumSriMismatch", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
+		emptyDigest := digestFunction.NewGenerator(0).Sum()
+		roundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:        "200 Success",
+				StatusCode:    200,
+				Body:          io.NopCloser(bytes.NewBuffer([]byte(TestData))),
+				ContentLength: 5,
+			}, nil
+		})
+
+		response, err := HTTPFetcher.FetchBlob(ctx, &remoteasset.FetchBlobRequest{
+			InstanceName: InstanceName,
+			Uris:         []string{uri, "www.another.com"},
+			Qualifiers: []*remoteasset.Qualifier{
+				{
+					Name:  "checksum.sri",
+					Value: digestToChecksumSri(remoteexecution.DigestFunction_SHA256, emptyDigest),
+				},
+			},
+		})
+		testutil.RequireEqualStatus(t, status.Error(codes.Internal, "Fetched content did not match checksum.sri qualifier: Expected e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, Got 185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969"), err)
+		require.Nil(t, response)
+		requireNoTemporaryFiles(t, tempDir)
+	})
+
 	t.Run("OneFailOneSuccess", func(t *testing.T) {
 		httpFailCall := roundTripper.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
 			Status:     "404 Not Found",
@@ -305,7 +419,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			Body:          body,
 			ContentLength: 5,
 		}, nil).After(httpFailCall)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpSuccessCall)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest).After(httpSuccessCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
@@ -352,7 +466,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			Body:          body,
 			ContentLength: 5,
 		}, nil)
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest).After(httpDoCall)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NoError(t, err)
@@ -408,7 +522,7 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			ContentLength: 5,
 		}, nil)
 
-		casBlobAccess.EXPECT().Put(ctx, helloDigest, gomock.Any()).Return(nil).After(httpDoCall2)
+		expectBlobPut(t, casBlobAccess, ctx, helloDigest).After(httpDoCall2)
 
 		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.Nil(t, err)


### PR DESCRIPTION
## Summary

- Stream HTTP response bodies to a temporary file instead of reading them fully into memory.
- Compute the CAS digest and optional `checksum.sri` digest incrementally while downloading.
- Pass a file-backed buffer to CAS, with the temporary file removed when the buffer is consumed or discarded.

## Motivation

`httpFetcher.downloadBlob()` currently uses `io.ReadAll(resp.Body)` before storing the blob in CAS. This means each in-flight HTTP fetch holds the full fetched object in memory until the subsequent CAS write completes.

This was motivated by a large deployment where we saw a large number of correlated OOMs coincident with the release of new, commonly used dependencies. That produced a burst of concurrent cache misses, and the fetcher's memory usage scaled with the sum of the in-flight object sizes.

This change keeps the same fetch, validate, and store behavior, but uses a temporary file as the handoff between the HTTP download and CAS upload so the full object body does not need to be resident in RAM.

## Validation

- `bazel test //pkg/fetch:fetch_test --test_env=PATH=/bin:/usr/bin:/usr/local/bin`

The tests cover:

- Successful fetches with and without `Content-Length`.
- Successful fetches with and without `checksum.sri`.
- Checksum mismatch behavior.
- File-backed buffer consumption through both chunk-reader and writer paths.
- Temporary file cleanup after success and checksum failure.
